### PR TITLE
Parse `shipment.create_date` as datetime

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,5 +1,8 @@
 Changelog
 =========
 
+- :release:`0.2.0 <13th May 2025>`
+- :feature:`-` Make ``shipment.create_date`` an actual datetime field
+
 - :release:`0.1.0 <6th May 2025>`
 - :feature:`-` Initial release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "idi-shipstation-sdk"
-version = "0.1.0"
+version = "0.2.0"
 description = "ShipStation API SDK"
 authors = [
     { name = "Bradley Reynolds", email = "bradley.reynolds@impressdesigns.com" },

--- a/src/shipstation_sdk/models.py
+++ b/src/shipstation_sdk/models.py
@@ -1,5 +1,7 @@
 """ShipStation API models."""
 
+from datetime import datetime
+
 from pydantic import BaseModel, Field
 
 
@@ -64,7 +66,7 @@ class Shipment(BaseModel):
     user_id: str = Field(..., alias="userId")
     customer_email: str | None = Field(..., alias="customerEmail")
     order_number: str = Field(..., alias="orderNumber")
-    create_date: str = Field(..., alias="createDate")
+    create_date: datetime = Field(..., alias="createDate")
     ship_date: str = Field(..., alias="shipDate")
     shipment_cost: float = Field(..., alias="shipmentCost")
     insurance_cost: float = Field(..., alias="insuranceCost")

--- a/uv.lock
+++ b/uv.lock
@@ -274,7 +274,7 @@ wheels = [
 
 [[package]]
 name = "idi-shipstation-sdk"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Parse `shipment.create_date` as a datetime, allowing date operations.