### PR TITLE
Rewrite as a ShipStation API v2 client (1.0.0)

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,7 @@ Changelog
   connected-carrier and tag listing, and rate-limit-aware retries
 - :feature:`-` Remove every v1 (legacy) endpoint and model, including orders and the
   ``America/Los_Angeles`` datetime handling; v1 consumers should pin ``<1``
+- :feature:`-` HTTP via Niquests instead of HTTPX, matching the in-house SDKs
 
 - :release:`0.8.0 <30th January 2026>`
 - :bug:`-` Item option name is nullable

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+- :release:`1.0.0 <8th July 2026>`
+- :feature:`-` Rewrite as a ShipStation API v2 client: ``api-key`` header auth against
+  ``https://api.shipstation.com``, shipments list/get/iterate (v2 shipments are v1 orders),
+  connected-carrier and tag listing, and rate-limit-aware retries
+- :feature:`-` Remove every v1 (legacy) endpoint and model, including orders and the
+  ``America/Los_Angeles`` datetime handling; v1 consumers should pin ``<1``
+
 - :release:`0.8.0 <30th January 2026>`
 - :bug:`-` Item option name is nullable
 - :bug:`-` Order user ID is a string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.13"
-dependencies = ["pydantic>=2.9.2", "httpx>=0.27.2"]
+dependencies = ["pydantic>=2.9.2", "niquests>=3.19.1"]
 
 [project.urls]
 repository = "https://github.com/impressdesigns/shipstation-sdk/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "idi-shipstation-sdk"
-version = "0.8.0"
+version = "1.0.0"
 description = "ShipStation API SDK"
 authors = [
     { name = "Bradley Reynolds", email = "bradley.reynolds@impressdesigns.com" },
@@ -61,6 +61,7 @@ ignore = [
 ]
 "tests/*" = [
     "S101", # (Use of `assert` detected) - Yes, that's the point
+    "PLR2004", # (Magic value used in comparison) - Tests compare against fixture values
 ]
 
 [tool.ruff.lint.isort]

--- a/src/shipstation_sdk/client.py
+++ b/src/shipstation_sdk/client.py
@@ -4,6 +4,7 @@ import time
 from collections.abc import Iterator
 from http import HTTPStatus
 from typing import Any
+from urllib.parse import quote
 
 import niquests
 
@@ -113,8 +114,14 @@ class ShipStationClient:
         return Shipment.model_validate(response.json())
 
     def get_shipment_by_external_id(self, external_shipment_id: str) -> Shipment:
-        """Get a specific shipment by the external shipment ID it was created with."""
-        response = self.make_request("GET", f"/v2/shipments/external_shipment_id/{external_shipment_id}")
+        """Get a specific shipment by the external shipment ID it was created with.
+
+        External shipment IDs are caller-defined and may contain URL metacharacters
+        (e.g. marketplace IDs like ``gid://...``), so the path segment is escaped.
+        """
+        response = self.make_request(
+            "GET", f"/v2/shipments/external_shipment_id/{quote(external_shipment_id, safe='')}",
+        )
         response.raise_for_status()
         return Shipment.model_validate(response.json())
 

--- a/src/shipstation_sdk/client.py
+++ b/src/shipstation_sdk/client.py
@@ -120,7 +120,8 @@ class ShipStationClient:
         (e.g. marketplace IDs like ``gid://...``), so the path segment is escaped.
         """
         response = self.make_request(
-            "GET", f"/v2/shipments/external_shipment_id/{quote(external_shipment_id, safe='')}",
+            "GET",
+            f"/v2/shipments/external_shipment_id/{quote(external_shipment_id, safe='')}",
         )
         response.raise_for_status()
         return Shipment.model_validate(response.json())

--- a/src/shipstation_sdk/client.py
+++ b/src/shipstation_sdk/client.py
@@ -2,6 +2,8 @@
 
 import time
 from collections.abc import Iterator
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
 from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
@@ -22,13 +24,19 @@ def _retry_after_seconds(response: niquests.Response) -> float:
     Parameters
     ----------
     response
-        The 429 response, whose ``Retry-After`` header (in seconds) is honored
-        when present, capped at ``MAX_RETRY_AFTER_SECONDS``.
+        The 429 response, whose ``Retry-After`` header is honored in either RFC 9110
+        form -- delta-seconds or an HTTP-date -- capped at ``MAX_RETRY_AFTER_SECONDS``.
     """
-    try:
-        seconds = float(response.headers["Retry-After"])
-    except (KeyError, ValueError):
+    header = response.headers.get("Retry-After")
+    if header is None:
         return DEFAULT_RETRY_AFTER_SECONDS
+    try:
+        seconds = float(header)
+    except ValueError:
+        try:
+            seconds = (parsedate_to_datetime(header) - datetime.now(tz=UTC)).total_seconds()
+        except (TypeError, ValueError):
+            return DEFAULT_RETRY_AFTER_SECONDS
     return min(max(seconds, 0.0), MAX_RETRY_AFTER_SECONDS)
 
 

--- a/src/shipstation_sdk/client.py
+++ b/src/shipstation_sdk/client.py
@@ -5,7 +5,7 @@ from collections.abc import Iterator
 from http import HTTPStatus
 from typing import Any
 
-from httpx import BaseTransport, Client, Response
+import niquests
 
 from .models import CarriersList, Shipment, ShipmentsList, TagsList
 from .parameters import ShipmentListParameters
@@ -15,7 +15,7 @@ DEFAULT_RETRY_AFTER_SECONDS = 5.0
 MAX_RETRY_AFTER_SECONDS = 60.0
 
 
-def _retry_after_seconds(response: Response) -> float:
+def _retry_after_seconds(response: niquests.Response) -> float:
     """Determine how long to sleep before retrying a rate-limited request.
 
     Parameters
@@ -39,7 +39,6 @@ class ShipStationClient:
         api_key: str,
         base_url: str = "https://api.shipstation.com",
         timeout: float = 60.0,
-        transport: BaseTransport | None = None,
     ) -> None:
         """Initialize the ShipStationClient class.
 
@@ -51,15 +50,12 @@ class ShipStationClient:
             The API host.
         timeout
             The request timeout in seconds.
-        transport
-            Optional httpx transport override (useful for testing).
         """
-        self.client = Client(
+        self.session = niquests.Session(
             base_url=base_url,
-            headers={"api-key": api_key},
             timeout=timeout,
-            transport=transport,
         )
+        self.session.headers["api-key"] = api_key
 
     def make_request(
         self,
@@ -67,7 +63,7 @@ class ShipStationClient:
         path: str,
         params: dict[str, Any] | None = None,
         json: dict[str, Any] | None = None,
-    ) -> Response:
+    ) -> niquests.Response:
         """Make a request to ShipStation, retrying when rate-limited.
 
         Retries up to ``RETRY_ATTEMPTS`` total attempts on HTTP 429, sleeping the
@@ -84,12 +80,12 @@ class ShipStationClient:
         if json is not None:
             args["json"] = json
 
-        response = self.client.request(**args)
+        response = self.session.request(**args)
         for _attempt in range(RETRY_ATTEMPTS - 1):
             if response.status_code != HTTPStatus.TOO_MANY_REQUESTS:
                 break
             time.sleep(_retry_after_seconds(response))
-            response = self.client.request(**args)
+            response = self.session.request(**args)
         return response
 
     def list_shipments(self, parameters: ShipmentListParameters | None = None) -> ShipmentsList:

--- a/src/shipstation_sdk/client.py
+++ b/src/shipstation_sdk/client.py
@@ -1,29 +1,64 @@
 """Interacting with ShipStation."""
 
-from datetime import date
+import time
+from collections.abc import Iterator
+from http import HTTPStatus
 from typing import Any
 
-from httpx import Client, Response
+from httpx import BaseTransport, Client, Response
 
-from .models import Order, OrdersList, ShipmentsList
-from .parameters import OrderListParameters
+from .models import CarriersList, Shipment, ShipmentsList, TagsList
+from .parameters import ShipmentListParameters
+
+RETRY_ATTEMPTS = 3
+DEFAULT_RETRY_AFTER_SECONDS = 5.0
+MAX_RETRY_AFTER_SECONDS = 60.0
+
+
+def _retry_after_seconds(response: Response) -> float:
+    """Determine how long to sleep before retrying a rate-limited request.
+
+    Parameters
+    ----------
+    response
+        The 429 response, whose ``Retry-After`` header (in seconds) is honored
+        when present, capped at ``MAX_RETRY_AFTER_SECONDS``.
+    """
+    try:
+        seconds = float(response.headers["Retry-After"])
+    except (KeyError, ValueError):
+        return DEFAULT_RETRY_AFTER_SECONDS
+    return min(max(seconds, 0.0), MAX_RETRY_AFTER_SECONDS)
 
 
 class ShipStationClient:
-    """A class wrapping ShipStation interaction."""
+    """A class wrapping ShipStation API v2 interaction."""
 
     def __init__(
         self,
-        base_url: str,
-        client_id: str,
-        client_secret: str,
-        timeout: float,
+        api_key: str,
+        base_url: str = "https://api.shipstation.com",
+        timeout: float = 60.0,
+        transport: BaseTransport | None = None,
     ) -> None:
-        """Initialize the ShipStationClient class."""
+        """Initialize the ShipStationClient class.
+
+        Parameters
+        ----------
+        api_key
+            The ShipStation API v2 key, sent as the ``api-key`` header on every request.
+        base_url
+            The API host.
+        timeout
+            The request timeout in seconds.
+        transport
+            Optional httpx transport override (useful for testing).
+        """
         self.client = Client(
             base_url=base_url,
-            auth=(client_id, client_secret),
+            headers={"api-key": api_key},
             timeout=timeout,
+            transport=transport,
         )
 
     def make_request(
@@ -33,8 +68,12 @@ class ShipStationClient:
         params: dict[str, Any] | None = None,
         json: dict[str, Any] | None = None,
     ) -> Response:
-        """Make a request to ShipStation."""
-        args: dict[str, str | dict[str, str]] = {
+        """Make a request to ShipStation, retrying when rate-limited.
+
+        Retries up to ``RETRY_ATTEMPTS`` total attempts on HTTP 429, sleeping the
+        response's ``Retry-After`` (``DEFAULT_RETRY_AFTER_SECONDS`` when absent).
+        """
+        args: dict[str, Any] = {
             "url": path,
             "method": method,
         }
@@ -45,32 +84,52 @@ class ShipStationClient:
         if json is not None:
             args["json"] = json
 
-        return self.client.request(**args)  # type: ignore[arg-type]
+        response = self.client.request(**args)
+        for _attempt in range(RETRY_ATTEMPTS - 1):
+            if response.status_code != HTTPStatus.TOO_MANY_REQUESTS:
+                break
+            time.sleep(_retry_after_seconds(response))
+            response = self.client.request(**args)
+        return response
 
-    def get_shipments(
-        self,
-        ship_date_start: date | None = None,
-        ship_date_end: date | None = None,
-    ) -> ShipmentsList:
-        """Get a list of shipments."""
-        params = {}
-        if ship_date_start:
-            params["shipDateStart"] = ship_date_start.isoformat()
-        if ship_date_end:
-            params["shipDateEnd"] = ship_date_end.isoformat()
-        response = self.make_request("GET", "/shipments", params=params)
+    def list_shipments(self, parameters: ShipmentListParameters | None = None) -> ShipmentsList:
+        """Get a page of shipments."""
+        params = parameters.model_dump(mode="json", exclude_none=True) if parameters else {}
+        response = self.make_request("GET", "/v2/shipments", params=params)
         response.raise_for_status()
         return ShipmentsList.model_validate(response.json())
 
-    def get_orders(self, parameters: OrderListParameters | None = None) -> OrdersList:
-        """Get a list of orders."""
-        params = parameters.model_dump(mode="json", exclude_none=True, by_alias=True) if parameters else {}
-        response = self.make_request("GET", "/orders", params=params)
-        response.raise_for_status()
-        return OrdersList.model_validate(response.json())
+    def iter_shipments(self, parameters: ShipmentListParameters | None = None) -> Iterator[Shipment]:
+        """Iterate over every shipment matching the parameters, following pagination."""
+        parameters = parameters.model_copy() if parameters else ShipmentListParameters()
+        parameters.page = parameters.page or 1
+        while True:
+            shipments_list = self.list_shipments(parameters)
+            yield from shipments_list.shipments
+            if shipments_list.page >= shipments_list.pages:
+                return
+            parameters.page = shipments_list.page + 1
 
-    def get_order(self, order_id: int) -> Order:
-        """Get a specific order."""
-        response = self.make_request("GET", f"/orders/{order_id}")
+    def get_shipment(self, shipment_id: str) -> Shipment:
+        """Get a specific shipment."""
+        response = self.make_request("GET", f"/v2/shipments/{shipment_id}")
         response.raise_for_status()
-        return Order.model_validate(response.json())
+        return Shipment.model_validate(response.json())
+
+    def get_shipment_by_external_id(self, external_shipment_id: str) -> Shipment:
+        """Get a specific shipment by the external shipment ID it was created with."""
+        response = self.make_request("GET", f"/v2/shipments/external_shipment_id/{external_shipment_id}")
+        response.raise_for_status()
+        return Shipment.model_validate(response.json())
+
+    def list_carriers(self) -> CarriersList:
+        """Get the connected carrier accounts."""
+        response = self.make_request("GET", "/v2/carriers")
+        response.raise_for_status()
+        return CarriersList.model_validate(response.json())
+
+    def list_tags(self) -> TagsList:
+        """Get the tags defined on the account."""
+        response = self.make_request("GET", "/v2/tags")
+        response.raise_for_status()
+        return TagsList.model_validate(response.json())

--- a/src/shipstation_sdk/models.py
+++ b/src/shipstation_sdk/models.py
@@ -1,9 +1,24 @@
 """ShipStation API v2 models."""
 
 from datetime import date, datetime
-from typing import Any
+from typing import Annotated, Any
 
-from pydantic import BaseModel
+from pydantic import AliasChoices, BaseModel, BeforeValidator, Field
+
+
+def _date_from_timestamp(value: object) -> object:
+    """Accept full ISO timestamps for date fields, truncating to the calendar date.
+
+    ShipStation's schema declares plain dates, but documented response examples carry
+    full timestamps (e.g. ``2024-07-25T05:00:00.000Z``), which pydantic would reject
+    for a ``date`` field.
+    """
+    if isinstance(value, str) and "T" in value:
+        return datetime.fromisoformat(value).date()
+    return value
+
+
+ShipStationDate = Annotated[date, BeforeValidator(_date_from_timestamp)]
 
 
 class MonetaryValue(BaseModel):
@@ -17,7 +32,8 @@ class Weight(BaseModel):
     """Model for a weight."""
 
     value: float
-    unit: str
+    # The schema says ``unit`` but documented response examples say ``units``.
+    unit: str = Field(validation_alias=AliasChoices("unit", "units"))
 
 
 class Tag(BaseModel):
@@ -101,7 +117,7 @@ class Shipment(BaseModel):
     shipment_status: str | None = None
     created_at: datetime | None = None
     modified_at: datetime | None = None
-    ship_date: date | None = None
+    ship_date: ShipStationDate | None = None
     ship_by_date: datetime | None = None
     hold_until_date: datetime | None = None
     deliver_by_date: datetime | None = None
@@ -175,9 +191,14 @@ class Carrier(BaseModel):
 
 
 class CarriersList(BaseModel):
-    """Response model for the carriers list API."""
+    """Response model for the carriers list API.
+
+    The endpoint documents a 207 partial-success response; ``errors`` carries the
+    details of any carrier accounts that could not be returned.
+    """
 
     carriers: list[Carrier]
+    errors: list[dict[str, Any]] = []
 
 
 class TagsList(BaseModel):

--- a/src/shipstation_sdk/models.py
+++ b/src/shipstation_sdk/models.py
@@ -1,252 +1,186 @@
-"""ShipStation API models."""
+"""ShipStation API v2 models."""
 
 from datetime import date, datetime
-from typing import Annotated
-from zoneinfo import ZoneInfo
+from typing import Any
 
-from pydantic import AfterValidator, BaseModel, Field
-from pydantic.functional_serializers import PlainSerializer
-
-# https://www.shipstation.com/docs/api/requirements/#datetime-format-and-time-zone
-LA_TIMEZONE = ZoneInfo("America/Los_Angeles")
+from pydantic import BaseModel
 
 
-def add_timezone(value: datetime | None) -> datetime | None:
-    """Add timezone information to datetime fields."""
-    if value:
-        value = value.replace(tzinfo=LA_TIMEZONE)
-    return value
+class MonetaryValue(BaseModel):
+    """Model for a monetary amount and its currency."""
 
-
-def to_timezoneless_string(value: datetime | None) -> str | None:
-    """Convert datetime to a string without timezone information."""
-    if value:
-        return value.strftime("%Y-%m-%dT%H:%M:%S.") + f"{value.microsecond * 10:07d}"
-    return None
-
-
-ShipStationDateTime = Annotated[datetime, AfterValidator(add_timezone), PlainSerializer(to_timezoneless_string)]
-
-
-class Address(BaseModel):
-    """Model for an address."""
-
-    name: str | None
-    company: str | None
-    street1: str | None
-    street2: str | None
-    street3: str | None
-    city: str | None
-    state: str | None
-    postal_code: str | None = Field(..., alias="postalCode")
-    country: str | None
-    phone: str | None
-    residential: bool | None
-    address_verified: str | None = Field(..., alias="addressVerified")
+    currency: str
+    amount: float
 
 
 class Weight(BaseModel):
-    """Model for the weight of the shipment."""
+    """Model for a weight."""
 
     value: float
-    units: str
-    weight_units: int = Field(..., alias="WeightUnits")
+    unit: str
 
 
-class Dimensions(BaseModel):
-    """Model for the dimensions of the shipment."""
+class Tag(BaseModel):
+    """Model for a shipment tag."""
 
-    units: str
-    length: float
-    width: float
-    height: float
+    name: str
 
 
-class InsuranceOptions(BaseModel):
-    """Model for insurance options."""
+class ItemOption(BaseModel):
+    """Model for a shipment item option."""
 
-    provider: str | None
-    insure_shipment: bool = Field(..., alias="insureShipment")
-    insured_value: float = Field(..., alias="insuredValue")
+    name: str | None = None
+    value: str | None = None
 
 
-class ShipmentAdvancedOptions(BaseModel):
-    """Model for advanced options."""
+class Address(BaseModel):
+    """Model for a shipping address."""
 
-    bill_to_party: str | None = Field(..., alias="billToParty")
-    bill_to_account: str | None = Field(..., alias="billToAccount")
-    bill_to_postal_code: str | None = Field(..., alias="billToPostalCode")
-    bill_to_country_code: str | None = Field(..., alias="billToCountryCode")
-    store_id: int = Field(..., alias="storeId")
+    name: str | None = None
+    phone: str | None = None
+    email: str | None = None
+    company_name: str | None = None
+    address_line1: str | None = None
+    address_line2: str | None = None
+    address_line3: str | None = None
+    city_locality: str | None = None
+    state_province: str | None = None
+    postal_code: str | None = None
+    country_code: str | None = None
+    address_residential_indicator: str | None = None
+    instructions: str | None = None
+
+
+class ShipmentItem(BaseModel):
+    """Model for a shipment item (an order line)."""
+
+    name: str | None = None
+    sku: str | None = None
+    bundle_sku: str | None = None
+    upc: str | None = None
+    asin: str | None = None
+    quantity: int = 0
+    unit_price: float | None = None
+    tax_amount: float | None = None
+    shipping_amount: float | None = None
+    weight: Weight | None = None
+    sales_order_id: str | None = None
+    sales_order_item_id: str | None = None
+    external_order_id: str | None = None
+    external_order_item_id: str | None = None
+    item_id: str | None = None
+    product_id: str | None = None
+    # The double-l spelling is the ShipStation API's, not ours.
+    fullfilment_sku: str | None = None
+    allocation_status: str | None = None
+    inventory_location: str | None = None
+    image_url: str | None = None
+    order_source_code: str | None = None
+    options: list[ItemOption] = []
+
+
+class AdvancedShipmentOptions(BaseModel):
+    """Model for advanced shipment options."""
+
+    custom_field1: str | None = None
+    custom_field2: str | None = None
+    custom_field3: str | None = None
+    bill_to_party: str | None = None
+    bill_to_account: str | None = None
+    bill_to_postal_code: str | None = None
+    bill_to_country_code: str | None = None
 
 
 class Shipment(BaseModel):
-    """Model for a shipment."""
+    """Model for a shipment (the v2 equivalent of a v1 order)."""
 
-    shipment_id: int = Field(..., alias="shipmentId")
-    order_id: int = Field(..., alias="orderId")
-    order_key: str = Field(..., alias="orderKey")
-    user_id: str = Field(..., alias="userId")
-    customer_email: str | None = Field(..., alias="customerEmail")
-    order_number: str = Field(..., alias="orderNumber")
-    create_date: ShipStationDateTime = Field(..., alias="createDate")
-    ship_date: date = Field(..., alias="shipDate")
-    shipment_cost: float = Field(..., alias="shipmentCost")
-    insurance_cost: float = Field(..., alias="insuranceCost")
-    tracking_number: str = Field(..., alias="trackingNumber")
-    is_return_label: bool = Field(..., alias="isReturnLabel")
-    batch_number: int | None = Field(..., alias="batchNumber")
-    carrier_code: str = Field(..., alias="carrierCode")
-    service_code: str = Field(..., alias="serviceCode")
-    package_code: str | None = Field(..., alias="packageCode")
-    confirmation: bool | None
-    warehouse_id: int = Field(..., alias="warehouseId")
-    voided: bool
-    void_date: str | None = Field(..., alias="voidDate")
-    marketplace_notified: bool = Field(..., alias="marketplaceNotified")
-    notify_error_message: str | None = Field(..., alias="notifyErrorMessage")
-    ship_to: Address = Field(..., alias="shipTo")
-    weight: Weight
-    dimensions: Dimensions | None
-    insurance_options: InsuranceOptions = Field(..., alias="insuranceOptions")
-    advanced_options: ShipmentAdvancedOptions = Field(..., alias="advancedOptions")
-    shipment_items: None = Field(..., alias="shipmentItems")
-    label_data: None = Field(..., alias="labelData")
-    form_data: None = Field(..., alias="formData")
+    shipment_id: str
+    external_shipment_id: str | None = None
+    shipment_number: str | None = None
+    external_order_id: str | None = None
+    shipment_status: str | None = None
+    created_at: datetime | None = None
+    modified_at: datetime | None = None
+    ship_date: date | None = None
+    ship_by_date: datetime | None = None
+    hold_until_date: datetime | None = None
+    deliver_by_date: datetime | None = None
+    store_id: str | None = None
+    order_source_code: str | None = None
+    carrier_id: str | None = None
+    service_code: str | None = None
+    requested_shipment_service: str | None = None
+    comparison_rate_type: str | None = None
+    zone: int | None = None
+    warehouse_id: str | None = None
+    amount_paid: MonetaryValue | None = None
+    shipping_paid: MonetaryValue | None = None
+    tax_paid: MonetaryValue | None = None
+    retail_rate: MonetaryValue | None = None
+    ship_to: Address | None = None
+    ship_from: Address | None = None
+    return_to: Address | None = None
+    items: list[ShipmentItem] = []
+    tags: list[Tag] = []
+    packages: list[dict[str, Any]] = []
+    total_weight: Weight | None = None
+    notes_from_buyer: str | None = None
+    notes_to_buyer: str | None = None
+    notes_for_gift: str | None = None
+    internal_notes: str | None = None
+    is_gift: bool | None = None
+    is_return: bool | None = None
+    assigned_user: str | None = None
+    display_scheme: str | None = None
+    confirmation: str | None = None
+    insurance_provider: str | None = None
+    advanced_options: AdvancedShipmentOptions | None = None
+    customs: dict[str, Any] | None = None
+    tax_identifiers: list[dict[str, Any]] | None = None
+
+
+class PaginationLink(BaseModel):
+    """Model for a single pagination link."""
+
+    href: str | None = None
+
+
+class PaginationLinks(BaseModel):
+    """Model for the pagination links of a list response."""
+
+    first: PaginationLink | None = None
+    last: PaginationLink | None = None
+    prev: PaginationLink | None = None
+    next: PaginationLink | None = None
 
 
 class ShipmentsList(BaseModel):
-    """Response model for Shipments API."""
+    """Response model for the shipments list API."""
 
     shipments: list[Shipment]
     total: int
     page: int
     pages: int
+    links: PaginationLinks | None = None
 
 
-class Option(BaseModel):
-    """Model for an order item option."""
+class Carrier(BaseModel):
+    """Model for a connected carrier account."""
 
-    name: str | None
-    value: str
-
-
-class Item(BaseModel):
-    """Model for an order item."""
-
-    order_item_id: int = Field(..., alias="orderItemId")
-    line_item_key: str | None = Field(..., alias="lineItemKey")
-    sku: str | None
-    name: str
-    image_url: str | None = Field(..., alias="imageUrl")
-    weight: Weight | None
-    quantity: int
-    unit_price: float = Field(..., alias="unitPrice")
-    tax_amount: float | None = Field(..., alias="taxAmount")
-    shipping_amount: float | None = Field(..., alias="shippingAmount")
-    warehouse_location: str | None = Field(..., alias="warehouseLocation")
-    options: list[Option]
-    product_id: int | None = Field(..., alias="productId")
-    fulfillment_sku: str | None = Field(..., alias="fulfillmentSku")
-    adjustment: bool
-    upc: str | None
-    create_date: str = Field(..., alias="createDate")
-    modify_date: str = Field(..., alias="modifyDate")
+    carrier_id: str
+    carrier_code: str
+    friendly_name: str | None = None
+    nickname: str | None = None
+    account_number: str | None = None
 
 
-class CustomsItem(BaseModel):
-    """Model for customs item."""
+class CarriersList(BaseModel):
+    """Response model for the carriers list API."""
 
-    customs_item_id: int = Field(..., alias="customsItemId")
-    description: str
-    quantity: int
-    value: float
-    harmonized_tariff_code: str | None = Field(..., alias="harmonizedTariffCode")
-    country_of_origin: str = Field(..., alias="countryOfOrigin")
+    carriers: list[Carrier]
 
 
-class InternationalOptions(BaseModel):
-    """Model for international shipping options."""
+class TagsList(BaseModel):
+    """Response model for the tags list API."""
 
-    contents: str | None
-    customs_items: list[CustomsItem] | None = Field(..., alias="customsItems")
-    non_delivery: str | None = Field(..., alias="nonDelivery")
-
-
-class OrderAdvancedOptions(BaseModel):
-    """Model for advanced options."""
-
-    warehouse_id: int = Field(..., alias="warehouseId")
-    non_machinable: bool = Field(..., alias="nonMachinable")
-    saturday_delivery: bool = Field(..., alias="saturdayDelivery")
-    contains_alcohol: bool = Field(..., alias="containsAlcohol")
-    merged_or_split: bool = Field(..., alias="mergedOrSplit")
-    merged_ids: list[int] = Field(..., alias="mergedIds")
-    parent_id: int | None = Field(..., alias="parentId")
-    store_id: int = Field(..., alias="storeId")
-    custom_field_1: str | None = Field(..., alias="customField1")
-    custom_field_2: str | None = Field(..., alias="customField2")
-    custom_field_3: str | None = Field(..., alias="customField3")
-    source: str | None = Field(..., alias="source")
-    bill_to_party: str | None = Field(..., alias="billToParty")
-    bill_to_account: str | None = Field(..., alias="billToAccount")
-    bill_to_postal_code: str | None = Field(..., alias="billToPostalCode")
-    bill_to_country_code: str | None = Field(..., alias="billToCountryCode")
-    bill_to_my_other_account: int | None = Field(..., alias="billToMyOtherAccount")
-
-
-class Order(BaseModel):
-    """Model for an order."""
-
-    order_id: int = Field(..., alias="orderId")
-    order_number: str = Field(..., alias="orderNumber")
-    order_key: str = Field(..., alias="orderKey")
-    order_date: ShipStationDateTime = Field(..., alias="orderDate")
-    create_date: ShipStationDateTime = Field(..., alias="createDate")
-    modify_date: ShipStationDateTime = Field(..., alias="modifyDate")
-    payment_date: ShipStationDateTime | None = Field(..., alias="paymentDate")
-    ship_by_date: ShipStationDateTime | None = Field(..., alias="shipByDate")
-    order_status: str | None = Field(..., alias="orderStatus")
-    customer_id: int | None = Field(..., alias="customerId")
-    customer_username: str | None = Field(..., alias="customerUsername")
-    customer_email: str | None = Field(..., alias="customerEmail")
-    bill_to: Address = Field(..., alias="billTo")
-    ship_to: Address = Field(..., alias="shipTo")
-    items: list[Item] | None
-    order_total: float | None = Field(..., alias="orderTotal")
-    amount_paid: float | None = Field(..., alias="amountPaid")
-    tax_amount: float | None = Field(..., alias="taxAmount")
-    shipping_amount: float | None = Field(..., alias="shippingAmount")
-    customer_notes: str | None = Field(..., alias="customerNotes")
-    internal_notes: str | None = Field(..., alias="internalNotes")
-    gift: bool
-    gift_message: str | None = Field(..., alias="giftMessage")
-    payment_method: str | None = Field(..., alias="paymentMethod")
-    requested_shipping_service: str | None = Field(..., alias="requestedShippingService")
-    carrier_code: str | None = Field(..., alias="carrierCode")
-    service_code: str | None = Field(..., alias="serviceCode")
-    package_code: str | None = Field(..., alias="packageCode")
-    confirmation: str
-    ship_date: date | None = Field(..., alias="shipDate")
-    hold_until_date: date | None = Field(..., alias="holdUntilDate")
-    weight: Weight
-    dimensions: Dimensions | None
-    insurance_options: InsuranceOptions = Field(..., alias="insuranceOptions")
-    international_options: InternationalOptions = Field(..., alias="internationalOptions")
-    advanced_options: OrderAdvancedOptions = Field(..., alias="advancedOptions")
-    tag_ids: list[int] | None = Field(..., alias="tagIds")
-    user_id: str | None = Field(..., alias="userId")
-    externally_fulfilled: bool = Field(..., alias="externallyFulfilled")
-    externally_fulfilled_by: str | None = Field(..., alias="externallyFulfilledBy")
-    externally_fulfilled_by_id: int | None = Field(None, alias="externallyFulfilledById")
-    externally_fulfilled_by_name: str | None = Field(None, alias="externallyFulfilledByName")
-    label_messages: list[str] | None = Field(..., alias="labelMessages")
-
-
-class OrdersList(BaseModel):
-    """Model for a list of orders."""
-
-    orders: list[Order]
-    total: int
-    page: int
-    pages: int
+    tags: list[Tag]

--- a/src/shipstation_sdk/parameters.py
+++ b/src/shipstation_sdk/parameters.py
@@ -29,6 +29,7 @@ class ShipmentListParameters(BaseModel, strict=True):
     shipment_status: ShipmentStatus | None = None
     store_id: str | None = None
     batch_id: str | None = None
+    tag: str | None = None
     sales_order_id: str | None = None
     shipment_number: str | None = None
     external_shipment_id: str | None = None

--- a/src/shipstation_sdk/parameters.py
+++ b/src/shipstation_sdk/parameters.py
@@ -1,49 +1,46 @@
 """Parameters for ShipStation API requests."""
 
-from datetime import date
+from datetime import datetime
 from typing import Literal
 
 from pydantic import BaseModel, Field
 
-type OrderStatus = Literal[
-    "awaiting_payment",
-    "awaiting_shipment",
-    "pending_fulfillment",
-    "shipped",
-    "on_hold",
+type ShipmentStatus = Literal[
+    "pending",
+    "processing",
+    "label_purchased",
     "cancelled",
-    "rejected_fulfillment",
 ]
 
-type OrderSortKey = Literal[
-    "OrderDate",
-    "ModifyDate",
-    "CreateDate",
+type ShipmentSortKey = Literal[
+    "modified_at",
+    "created_at",
 ]
 
 type SortDirection = Literal[
-    "ASC",
-    "DESC",
+    "asc",
+    "desc",
 ]
 
 
-class OrderListParameters(BaseModel, strict=True):
-    """Parameters for listing orders."""
+class ShipmentListParameters(BaseModel, strict=True):
+    """Parameters for listing shipments."""
 
-    customer_name: str | None = Field(None, alias="customerName")
-    item_keyword: str | None = Field(None, alias="itemKeyword")
-    create_date_start: date | None = Field(None, alias="createDateStart")
-    create_date_end: date | None = Field(None, alias="createDateEnd")
-    modify_date_start: date | None = Field(None, alias="modifyDateStart")
-    modify_date_end: date | None = Field(None, alias="modifyDateEnd")
-    order_date_start: date | None = Field(None, alias="orderDateStart")
-    order_date_end: date | None = Field(None, alias="orderDateEnd")
-    order_number: str | None = Field(None, alias="orderNumber")
-    order_status: OrderStatus | None = Field(None, alias="orderStatus")
-    payment_date_start: date | None = Field(None, alias="paymentDateStart")
-    payment_date_end: date | None = Field(None, alias="paymentDateEnd")
-    store_id: int | None = Field(None, alias="storeId")
-    sort_by: OrderSortKey | None = Field(None, alias="sortBy")
-    sort_dir: SortDirection | None = Field(None, alias="sortDir")
-    page: int | None = Field(None, alias="page")
-    page_size: int | None = Field(None, ge=1, le=500, alias="pageSize")
+    shipment_status: ShipmentStatus | None = None
+    store_id: str | None = None
+    batch_id: str | None = None
+    sales_order_id: str | None = None
+    shipment_number: str | None = None
+    external_shipment_id: str | None = None
+    item_keyword: str | None = None
+    ship_to_name: str | None = None
+    created_at_start: datetime | None = None
+    created_at_end: datetime | None = None
+    modified_at_start: datetime | None = None
+    modified_at_end: datetime | None = None
+    payment_date_start: datetime | None = None
+    payment_date_end: datetime | None = None
+    sort_by: ShipmentSortKey | None = None
+    sort_dir: SortDirection | None = None
+    page: int | None = Field(None, ge=1)
+    page_size: int | None = Field(None, ge=1)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -171,6 +171,28 @@ def test_get_shipment_by_external_id_fetches_by_external_id(monkeypatch: pytest.
     assert recorder.calls[0]["url"] == "/v2/shipments/external_shipment_id/my-order-123"
 
 
+def test_get_shipment_by_external_id_escapes_url_metacharacters(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Caller-defined external IDs (e.g. marketplace ``gid://...``) are path-escaped."""
+    client = ShipStationClient(api_key="test-key")
+    recorder = _record(client, monkeypatch, [_response(200, MINIMAL_SHIPMENT)])
+
+    client.get_shipment_by_external_id("gid://shopify/Order/1?x=1#frag")
+
+    assert recorder.calls[0]["url"] == (
+        "/v2/shipments/external_shipment_id/gid%3A%2F%2Fshopify%2FOrder%2F1%3Fx%3D1%23frag"
+    )
+
+
+def test_list_shipments_serializes_the_tag_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The ``tag`` filter (documented in the list-shipments guide) reaches the query params."""
+    client = ShipStationClient(api_key="test-key")
+    recorder = _record(client, monkeypatch, [_shipments_page(1, 1, [MINIMAL_SHIPMENT])])
+
+    client.list_shipments(ShipmentListParameters(tag="Rush"))
+
+    assert recorder.calls[0]["params"] == {"tag": "Rush"}
+
+
 def test_make_request_passes_json_bodies_through(monkeypatch: pytest.MonkeyPatch) -> None:
     """The generic escape hatch passes JSON bodies through untouched."""
     client = ShipStationClient(api_key="test-key")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,8 @@
 """Tests for the ShipStation API v2 client."""
 
 import json
+from datetime import UTC, datetime, timedelta
+from email.utils import format_datetime
 from http import HTTPStatus
 from typing import Any
 
@@ -202,3 +204,27 @@ def test_make_request_passes_json_bodies_through(monkeypatch: pytest.MonkeyPatch
 
     assert response.status_code == HTTPStatus.OK
     assert recorder.calls[0]["json"] == {"example": True}
+
+
+def test_retry_after_accepts_an_http_date() -> None:
+    """RFC 9110 allows an HTTP-date ``Retry-After``; it converts to a bounded delay."""
+    future = format_datetime(datetime.now(tz=UTC) + timedelta(seconds=30), usegmt=True)
+    past = format_datetime(datetime.now(tz=UTC) - timedelta(seconds=30), usegmt=True)
+
+    future_delay = _retry_after_seconds(_response(429, headers={"Retry-After": future}))
+    past_delay = _retry_after_seconds(_response(429, headers={"Retry-After": past}))
+
+    assert 20.0 < future_delay <= 30.0
+    assert past_delay == 0.0
+
+
+def test_list_tags_fetches_the_account_tags(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``list_tags`` GETs the tags path and validates the envelope."""
+    client = ShipStationClient(api_key="test-key")
+    recorder = _record(client, monkeypatch, [_response(200, {"tags": [{"name": "Rush"}]})])
+
+    tags_list = client.list_tags()
+
+    assert recorder.calls[0]["method"] == "GET"
+    assert recorder.calls[0]["url"] == "/v2/tags"
+    assert [tag.name for tag in tags_list.tags] == ["Rush"]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,176 @@
+"""Tests for the ShipStation API v2 client."""
+
+import json
+from http import HTTPStatus
+from typing import Any
+
+import pytest
+from httpx import MockTransport, Request, Response
+
+from shipstation_sdk import ShipStationClient
+from shipstation_sdk.client import (
+    DEFAULT_RETRY_AFTER_SECONDS,
+    MAX_RETRY_AFTER_SECONDS,
+    RETRY_ATTEMPTS,
+    _retry_after_seconds,
+)
+from shipstation_sdk.parameters import ShipmentListParameters
+
+MINIMAL_SHIPMENT: dict[str, Any] = {"shipment_id": "se-28529731", "shipment_status": "pending"}
+
+
+def _shipments_page(page: int, pages: int, shipments: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build a shipments list response body."""
+    return {"shipments": shipments, "total": len(shipments) * pages, "page": page, "pages": pages}
+
+
+def test_requests_carry_the_api_key_header() -> None:
+    """Every request authenticates with the ``api-key`` header."""
+    seen_headers: list[str | None] = []
+
+    def handler(request: Request) -> Response:
+        seen_headers.append(request.headers.get("api-key"))
+        return Response(200, json={"tags": []})
+
+    client = ShipStationClient(api_key="test-key", transport=MockTransport(handler))
+    client.list_tags()
+
+    assert seen_headers == ["test-key"]
+
+
+def test_list_shipments_sends_parameters_as_query_params() -> None:
+    """List parameters serialize 1:1 onto the ``/v2/shipments`` query string."""
+    seen_requests: list[Request] = []
+
+    def handler(request: Request) -> Response:
+        seen_requests.append(request)
+        return Response(200, json=_shipments_page(1, 1, [MINIMAL_SHIPMENT]))
+
+    client = ShipStationClient(api_key="test-key", transport=MockTransport(handler))
+    shipments_list = client.list_shipments(
+        ShipmentListParameters(shipment_status="pending", store_id="se-521526", page_size=100),
+    )
+
+    assert shipments_list.shipments[0].shipment_id == "se-28529731"
+    request = seen_requests[0]
+    assert request.url.path == "/v2/shipments"
+    assert request.url.params["shipment_status"] == "pending"
+    assert request.url.params["store_id"] == "se-521526"
+    assert request.url.params["page_size"] == "100"
+
+
+def test_iter_shipments_walks_every_page() -> None:
+    """The pagination helper follows ``page``/``pages`` to the end."""
+    pages = {
+        1: _shipments_page(1, 3, [{"shipment_id": "se-1"}]),
+        2: _shipments_page(2, 3, [{"shipment_id": "se-2"}]),
+        3: _shipments_page(3, 3, [{"shipment_id": "se-3"}]),
+    }
+    requested_pages: list[int] = []
+
+    def handler(request: Request) -> Response:
+        page = int(request.url.params["page"])
+        requested_pages.append(page)
+        return Response(200, json=pages[page])
+
+    client = ShipStationClient(api_key="test-key", transport=MockTransport(handler))
+    shipment_ids = [shipment.shipment_id for shipment in client.iter_shipments()]
+
+    assert shipment_ids == ["se-1", "se-2", "se-3"]
+    assert requested_pages == [1, 2, 3]
+
+
+def test_iter_shipments_does_not_mutate_the_callers_parameters() -> None:
+    """The pagination helper pages on a copy of the caller's parameters."""
+
+    def handler(_request: Request) -> Response:
+        return Response(200, json=_shipments_page(1, 2, [MINIMAL_SHIPMENT]))
+
+    client = ShipStationClient(api_key="test-key", transport=MockTransport(handler))
+    parameters = ShipmentListParameters(shipment_status="pending")
+    iterator = client.iter_shipments(parameters)
+    next(iterator)
+
+    assert parameters.page is None
+
+
+def test_make_request_retries_rate_limited_requests(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 429 is retried after the ``Retry-After`` delay until a page succeeds."""
+    responses = [
+        Response(429, headers={"Retry-After": "7"}),
+        Response(200, json={"carriers": [{"carrier_id": "se-1", "carrier_code": "ups"}]}),
+    ]
+    sleeps: list[float] = []
+    monkeypatch.setattr("shipstation_sdk.client.time.sleep", sleeps.append)
+
+    def handler(_request: Request) -> Response:
+        return responses.pop(0)
+
+    client = ShipStationClient(api_key="test-key", transport=MockTransport(handler))
+    carriers_list = client.list_carriers()
+
+    assert sleeps == [7.0]
+    assert carriers_list.carriers[0].carrier_code == "ups"
+
+
+def test_make_request_gives_up_after_three_rate_limited_attempts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Persistent 429s are returned to the caller after the retry budget is spent."""
+    attempts: list[Request] = []
+    monkeypatch.setattr("shipstation_sdk.client.time.sleep", lambda _seconds: None)
+
+    def handler(request: Request) -> Response:
+        attempts.append(request)
+        return Response(429)
+
+    client = ShipStationClient(api_key="test-key", transport=MockTransport(handler))
+    response = client.make_request("GET", "/v2/shipments")
+
+    assert response.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert len(attempts) == RETRY_ATTEMPTS
+
+
+def test_retry_after_header_is_bounded() -> None:
+    """Missing, malformed, and oversized ``Retry-After`` headers are handled."""
+    assert _retry_after_seconds(Response(429)) == DEFAULT_RETRY_AFTER_SECONDS
+    assert _retry_after_seconds(Response(429, headers={"Retry-After": "junk"})) == DEFAULT_RETRY_AFTER_SECONDS
+    assert _retry_after_seconds(Response(429, headers={"Retry-After": "3600"})) == MAX_RETRY_AFTER_SECONDS
+    assert _retry_after_seconds(Response(429, headers={"Retry-After": "-1"})) == 0.0
+
+
+def test_get_shipment_fetches_by_id() -> None:
+    """``get_shipment`` GETs the shipment path and validates the bare body."""
+
+    def handler(request: Request) -> Response:
+        assert request.url.path == "/v2/shipments/se-28529731"
+        return Response(200, json=MINIMAL_SHIPMENT)
+
+    client = ShipStationClient(api_key="test-key", transport=MockTransport(handler))
+    shipment = client.get_shipment("se-28529731")
+
+    assert shipment.shipment_id == "se-28529731"
+
+
+def test_get_shipment_by_external_id_fetches_by_external_id() -> None:
+    """``get_shipment_by_external_id`` GETs the external-id lookup path."""
+
+    def handler(request: Request) -> Response:
+        assert request.url.path == "/v2/shipments/external_shipment_id/my-order-123"
+        return Response(200, json=MINIMAL_SHIPMENT)
+
+    client = ShipStationClient(api_key="test-key", transport=MockTransport(handler))
+    shipment = client.get_shipment_by_external_id("my-order-123")
+
+    assert shipment.shipment_id == "se-28529731"
+
+
+def test_make_request_sends_json_bodies() -> None:
+    """The generic escape hatch passes JSON bodies through."""
+
+    def handler(request: Request) -> Response:
+        assert json.loads(request.content) == {"example": True}
+        return Response(200, json={})
+
+    client = ShipStationClient(api_key="test-key", transport=MockTransport(handler))
+    response = client.make_request("POST", "/v2/shipments", json={"example": True})
+
+    assert response.status_code == HTTPStatus.OK

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,7 +5,7 @@ from http import HTTPStatus
 from typing import Any
 
 import pytest
-from httpx import MockTransport, Request, Response
+from niquests import Response
 
 from shipstation_sdk import ShipStationClient
 from shipstation_sdk.client import (
@@ -19,94 +19,110 @@ from shipstation_sdk.parameters import ShipmentListParameters
 MINIMAL_SHIPMENT: dict[str, Any] = {"shipment_id": "se-28529731", "shipment_status": "pending"}
 
 
-def _shipments_page(page: int, pages: int, shipments: list[dict[str, Any]]) -> dict[str, Any]:
-    """Build a shipments list response body."""
-    return {"shipments": shipments, "total": len(shipments) * pages, "page": page, "pages": pages}
+def _response(
+    status_code: int,
+    body: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+) -> Response:
+    """Build a niquests Response without touching the network."""
+    response = Response()
+    response.status_code = status_code
+    response._content = json.dumps(body or {}).encode()  # noqa: SLF001 -- no public way to seed a canned body
+    response.headers.update(headers or {})
+    return response
 
 
-def test_requests_carry_the_api_key_header() -> None:
-    """Every request authenticates with the ``api-key`` header."""
-    seen_headers: list[str | None] = []
+class _SessionRecorder:
+    """Stand-in for ``Session.request`` serving canned responses and recording calls."""
 
-    def handler(request: Request) -> Response:
-        seen_headers.append(request.headers.get("api-key"))
-        return Response(200, json={"tags": []})
+    def __init__(self, responses: list[Response]) -> None:
+        self.responses = responses
+        self.calls: list[dict[str, Any]] = []
 
-    client = ShipStationClient(api_key="test-key", transport=MockTransport(handler))
-    client.list_tags()
-
-    assert seen_headers == ["test-key"]
+    def request(self, **kwargs: Any) -> Response:  # noqa: ANN401 -- mirrors Session.request's open signature
+        self.calls.append(kwargs)
+        return self.responses.pop(0)
 
 
-def test_list_shipments_sends_parameters_as_query_params() -> None:
-    """List parameters serialize 1:1 onto the ``/v2/shipments`` query string."""
-    seen_requests: list[Request] = []
+def _record(client: ShipStationClient, monkeypatch: pytest.MonkeyPatch, responses: list[Response]) -> _SessionRecorder:
+    """Route the client's session requests through a recorder."""
+    recorder = _SessionRecorder(responses)
+    monkeypatch.setattr(client.session, "request", recorder.request)
+    return recorder
 
-    def handler(request: Request) -> Response:
-        seen_requests.append(request)
-        return Response(200, json=_shipments_page(1, 1, [MINIMAL_SHIPMENT]))
 
-    client = ShipStationClient(api_key="test-key", transport=MockTransport(handler))
+def _shipments_page(page: int, pages: int, shipments: list[dict[str, Any]]) -> Response:
+    """Build a shipments list response."""
+    return _response(200, {"shipments": shipments, "total": len(shipments) * pages, "page": page, "pages": pages})
+
+
+def test_session_carries_the_api_key_header() -> None:
+    """The session authenticates every request with the ``api-key`` header."""
+    client = ShipStationClient(api_key="test-key")
+
+    assert client.session.headers["api-key"] == "test-key"
+
+
+def test_list_shipments_sends_parameters_as_query_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    """List parameters serialize 1:1 onto the ``/v2/shipments`` query params."""
+    client = ShipStationClient(api_key="test-key")
+    recorder = _record(client, monkeypatch, [_shipments_page(1, 1, [MINIMAL_SHIPMENT])])
+
     shipments_list = client.list_shipments(
         ShipmentListParameters(shipment_status="pending", store_id="se-521526", page_size=100),
     )
 
     assert shipments_list.shipments[0].shipment_id == "se-28529731"
-    request = seen_requests[0]
-    assert request.url.path == "/v2/shipments"
-    assert request.url.params["shipment_status"] == "pending"
-    assert request.url.params["store_id"] == "se-521526"
-    assert request.url.params["page_size"] == "100"
+    call = recorder.calls[0]
+    assert call["method"] == "GET"
+    assert call["url"] == "/v2/shipments"
+    assert call["params"] == {"shipment_status": "pending", "store_id": "se-521526", "page_size": 100}
 
 
-def test_iter_shipments_walks_every_page() -> None:
+def test_iter_shipments_walks_every_page(monkeypatch: pytest.MonkeyPatch) -> None:
     """The pagination helper follows ``page``/``pages`` to the end."""
-    pages = {
-        1: _shipments_page(1, 3, [{"shipment_id": "se-1"}]),
-        2: _shipments_page(2, 3, [{"shipment_id": "se-2"}]),
-        3: _shipments_page(3, 3, [{"shipment_id": "se-3"}]),
-    }
-    requested_pages: list[int] = []
+    client = ShipStationClient(api_key="test-key")
+    recorder = _record(
+        client,
+        monkeypatch,
+        [
+            _shipments_page(1, 3, [{"shipment_id": "se-1"}]),
+            _shipments_page(2, 3, [{"shipment_id": "se-2"}]),
+            _shipments_page(3, 3, [{"shipment_id": "se-3"}]),
+        ],
+    )
 
-    def handler(request: Request) -> Response:
-        page = int(request.url.params["page"])
-        requested_pages.append(page)
-        return Response(200, json=pages[page])
-
-    client = ShipStationClient(api_key="test-key", transport=MockTransport(handler))
     shipment_ids = [shipment.shipment_id for shipment in client.iter_shipments()]
 
     assert shipment_ids == ["se-1", "se-2", "se-3"]
-    assert requested_pages == [1, 2, 3]
+    assert [call["params"]["page"] for call in recorder.calls] == [1, 2, 3]
 
 
-def test_iter_shipments_does_not_mutate_the_callers_parameters() -> None:
+def test_iter_shipments_does_not_mutate_the_callers_parameters(monkeypatch: pytest.MonkeyPatch) -> None:
     """The pagination helper pages on a copy of the caller's parameters."""
-
-    def handler(_request: Request) -> Response:
-        return Response(200, json=_shipments_page(1, 2, [MINIMAL_SHIPMENT]))
-
-    client = ShipStationClient(api_key="test-key", transport=MockTransport(handler))
+    client = ShipStationClient(api_key="test-key")
+    _record(client, monkeypatch, [_shipments_page(1, 2, [MINIMAL_SHIPMENT])])
     parameters = ShipmentListParameters(shipment_status="pending")
-    iterator = client.iter_shipments(parameters)
-    next(iterator)
+
+    next(client.iter_shipments(parameters))
 
     assert parameters.page is None
 
 
 def test_make_request_retries_rate_limited_requests(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A 429 is retried after the ``Retry-After`` delay until a page succeeds."""
-    responses = [
-        Response(429, headers={"Retry-After": "7"}),
-        Response(200, json={"carriers": [{"carrier_id": "se-1", "carrier_code": "ups"}]}),
-    ]
+    """A 429 is retried after the ``Retry-After`` delay until a request succeeds."""
     sleeps: list[float] = []
     monkeypatch.setattr("shipstation_sdk.client.time.sleep", sleeps.append)
+    client = ShipStationClient(api_key="test-key")
+    _record(
+        client,
+        monkeypatch,
+        [
+            _response(429, headers={"Retry-After": "7"}),
+            _response(200, {"carriers": [{"carrier_id": "se-1", "carrier_code": "ups"}]}),
+        ],
+    )
 
-    def handler(_request: Request) -> Response:
-        return responses.pop(0)
-
-    client = ShipStationClient(api_key="test-key", transport=MockTransport(handler))
     carriers_list = client.list_carriers()
 
     assert sleeps == [7.0]
@@ -115,62 +131,52 @@ def test_make_request_retries_rate_limited_requests(monkeypatch: pytest.MonkeyPa
 
 def test_make_request_gives_up_after_three_rate_limited_attempts(monkeypatch: pytest.MonkeyPatch) -> None:
     """Persistent 429s are returned to the caller after the retry budget is spent."""
-    attempts: list[Request] = []
     monkeypatch.setattr("shipstation_sdk.client.time.sleep", lambda _seconds: None)
+    client = ShipStationClient(api_key="test-key")
+    recorder = _record(client, monkeypatch, [_response(429) for _ in range(RETRY_ATTEMPTS)])
 
-    def handler(request: Request) -> Response:
-        attempts.append(request)
-        return Response(429)
-
-    client = ShipStationClient(api_key="test-key", transport=MockTransport(handler))
     response = client.make_request("GET", "/v2/shipments")
 
     assert response.status_code == HTTPStatus.TOO_MANY_REQUESTS
-    assert len(attempts) == RETRY_ATTEMPTS
+    assert len(recorder.calls) == RETRY_ATTEMPTS
 
 
 def test_retry_after_header_is_bounded() -> None:
     """Missing, malformed, and oversized ``Retry-After`` headers are handled."""
-    assert _retry_after_seconds(Response(429)) == DEFAULT_RETRY_AFTER_SECONDS
-    assert _retry_after_seconds(Response(429, headers={"Retry-After": "junk"})) == DEFAULT_RETRY_AFTER_SECONDS
-    assert _retry_after_seconds(Response(429, headers={"Retry-After": "3600"})) == MAX_RETRY_AFTER_SECONDS
-    assert _retry_after_seconds(Response(429, headers={"Retry-After": "-1"})) == 0.0
+    assert _retry_after_seconds(_response(429)) == DEFAULT_RETRY_AFTER_SECONDS
+    assert _retry_after_seconds(_response(429, headers={"Retry-After": "junk"})) == DEFAULT_RETRY_AFTER_SECONDS
+    assert _retry_after_seconds(_response(429, headers={"Retry-After": "3600"})) == MAX_RETRY_AFTER_SECONDS
+    assert _retry_after_seconds(_response(429, headers={"Retry-After": "-1"})) == 0.0
 
 
-def test_get_shipment_fetches_by_id() -> None:
+def test_get_shipment_fetches_by_id(monkeypatch: pytest.MonkeyPatch) -> None:
     """``get_shipment`` GETs the shipment path and validates the bare body."""
+    client = ShipStationClient(api_key="test-key")
+    recorder = _record(client, monkeypatch, [_response(200, MINIMAL_SHIPMENT)])
 
-    def handler(request: Request) -> Response:
-        assert request.url.path == "/v2/shipments/se-28529731"
-        return Response(200, json=MINIMAL_SHIPMENT)
-
-    client = ShipStationClient(api_key="test-key", transport=MockTransport(handler))
     shipment = client.get_shipment("se-28529731")
 
     assert shipment.shipment_id == "se-28529731"
+    assert recorder.calls[0]["url"] == "/v2/shipments/se-28529731"
 
 
-def test_get_shipment_by_external_id_fetches_by_external_id() -> None:
+def test_get_shipment_by_external_id_fetches_by_external_id(monkeypatch: pytest.MonkeyPatch) -> None:
     """``get_shipment_by_external_id`` GETs the external-id lookup path."""
+    client = ShipStationClient(api_key="test-key")
+    recorder = _record(client, monkeypatch, [_response(200, MINIMAL_SHIPMENT)])
 
-    def handler(request: Request) -> Response:
-        assert request.url.path == "/v2/shipments/external_shipment_id/my-order-123"
-        return Response(200, json=MINIMAL_SHIPMENT)
-
-    client = ShipStationClient(api_key="test-key", transport=MockTransport(handler))
     shipment = client.get_shipment_by_external_id("my-order-123")
 
     assert shipment.shipment_id == "se-28529731"
+    assert recorder.calls[0]["url"] == "/v2/shipments/external_shipment_id/my-order-123"
 
 
-def test_make_request_sends_json_bodies() -> None:
-    """The generic escape hatch passes JSON bodies through."""
+def test_make_request_passes_json_bodies_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The generic escape hatch passes JSON bodies through untouched."""
+    client = ShipStationClient(api_key="test-key")
+    recorder = _record(client, monkeypatch, [_response(200)])
 
-    def handler(request: Request) -> Response:
-        assert json.loads(request.content) == {"example": True}
-        return Response(200, json={})
-
-    client = ShipStationClient(api_key="test-key", transport=MockTransport(handler))
     response = client.make_request("POST", "/v2/shipments", json={"example": True})
 
     assert response.status_code == HTTPStatus.OK
+    assert recorder.calls[0]["json"] == {"example": True}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,9 +1,9 @@
 """Tests for the ShipStation API v2 models."""
 
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from typing import Any
 
-from shipstation_sdk.models import Shipment, ShipmentsList
+from shipstation_sdk.models import CarriersList, Shipment, ShipmentsList, Weight
 
 # A realistic v2 shipment, hand-built from the published OpenAPI schema.
 SHIPMENT_JSON: dict[str, Any] = {
@@ -112,3 +112,29 @@ def test_shipment_parses_with_minimal_fields() -> None:
     assert shipment.items == []
     assert shipment.tags == []
     assert shipment.store_id is None
+
+
+def test_weight_accepts_both_unit_spellings() -> None:
+    """The schema says ``unit`` but documented examples say ``units`` — both parse."""
+    assert Weight.model_validate({"value": 9.6, "unit": "ounce"}).unit == "ounce"
+    assert Weight.model_validate({"value": 9.6, "units": "ounce"}).unit == "ounce"
+
+
+def test_ship_date_accepts_a_full_timestamp() -> None:
+    """Documented examples carry timestamps for ``ship_date``; they truncate to the date."""
+    shipment = Shipment.model_validate({"shipment_id": "se-1", "ship_date": "2024-07-25T05:00:00.000Z"})
+
+    assert shipment.ship_date == date(2024, 7, 25)
+
+
+def test_carriers_list_retains_partial_success_errors() -> None:
+    """A 207 partial-success body keeps its ``errors`` alongside the carriers."""
+    carriers_list = CarriersList.model_validate(
+        {
+            "carriers": [{"carrier_id": "se-1", "carrier_code": "ups"}],
+            "errors": [{"error": "connection to stamps_com failed"}],
+        },
+    )
+
+    assert [carrier.carrier_code for carrier in carriers_list.carriers] == ["ups"]
+    assert carriers_list.errors == [{"error": "connection to stamps_com failed"}]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,24 +1,114 @@
-"""Test for datetime serialization in ShipStation SDK models."""
+"""Tests for the ShipStation API v2 models."""
 
-from datetime import datetime
+from datetime import UTC, datetime
+from typing import Any
 
-from pydantic import BaseModel, Field
+from shipstation_sdk.models import Shipment, ShipmentsList
 
-from shipstation_sdk.models import LA_TIMEZONE, ShipStationDateTime
+# A realistic v2 shipment, hand-built from the published OpenAPI schema.
+SHIPMENT_JSON: dict[str, Any] = {
+    "shipment_id": "se-28529731",
+    "external_shipment_id": "9f8c6b1e-6a2f-4c1e-a2c8-1c1d2e3f4a5b",
+    "shipment_number": "AS-10001",
+    "external_order_id": "1234567890",
+    "shipment_status": "pending",
+    "created_at": "2026-07-01T16:30:00Z",
+    "modified_at": "2026-07-01T16:31:00Z",
+    "ship_by_date": "2026-07-07T00:00:00Z",
+    "store_id": "se-521526",
+    "order_source_code": "shopify",
+    "carrier_id": "se-123456",
+    "service_code": "ups_ground",
+    "requested_shipment_service": "UPS Ground",
+    "amount_paid": {"currency": "usd", "amount": 45.5},
+    "tax_paid": {"currency": "usd", "amount": 3.5},
+    "ship_to": {
+        "name": "Jane Doe",
+        "phone": "555-555-5555",
+        "email": "jane@example.com",
+        "company_name": "Example Corp",
+        "address_line1": "123 Main St",
+        "address_line2": "Suite 4",
+        "city_locality": "Dallas",
+        "state_province": "TX",
+        "postal_code": "75001",
+        "country_code": "US",
+        "address_residential_indicator": "no",
+    },
+    "items": [
+        {
+            "name": "Robe - Large",
+            "sku": "ROBE-L",
+            "upc": "012345678905",
+            "quantity": 2,
+            "unit_price": 20.0,
+            "sales_order_id": "se-987",
+            "sales_order_item_id": "se-654",
+            "external_order_item_id": "gid://shopify/LineItem/1",
+            "options": [
+                {"name": "Embroidery Text", "value": "Jane"},
+                {"name": "Embroidery Color", "value": "Red"},
+            ],
+        },
+    ],
+    "tags": [{"name": "Rush"}],
+    "packages": [{"package_code": "package", "weight": {"value": 1.5, "unit": "pound"}}],
+    "total_weight": {"value": 1.5, "unit": "pound"},
+    "notes_from_buyer": "Please hurry!",
+    "is_gift": False,
+    "advanced_options": {"custom_field1": "AS-10001", "bill_to_party": "recipient"},
+    "confirmation": "none",
+    "insurance_provider": "none",
+}
 
 
-class Example(BaseModel):
-    """Test model to validate datetime serialization."""
+def test_shipment_round_trip() -> None:
+    """A realistic v2 shipment body validates with the expected field types."""
+    shipment = Shipment.model_validate(SHIPMENT_JSON)
 
-    order_date: ShipStationDateTime = Field(..., alias="orderDate")
+    assert shipment.shipment_id == "se-28529731"
+    assert shipment.created_at == datetime(2026, 7, 1, 16, 30, tzinfo=UTC)
+    assert shipment.store_id == "se-521526"
+    assert shipment.amount_paid is not None
+    assert shipment.amount_paid.amount == 45.5
+    assert shipment.ship_to is not None
+    assert shipment.ship_to.city_locality == "Dallas"
+    assert shipment.items[0].options[1].value == "Red"
+    assert [tag.name for tag in shipment.tags] == ["Rush"]
+    assert shipment.advanced_options is not None
+    assert shipment.advanced_options.custom_field1 == "AS-10001"
 
 
-def test_datetime_serialization() -> None:
-    """Test the serialization of datetime fields."""
-    test_instance = Example.model_validate({"orderDate": "2025-06-05T12:52:00.0000000"})
+def test_shipments_list_envelope() -> None:
+    """The list envelope parses pagination fields and links."""
+    shipments_list = ShipmentsList.model_validate(
+        {
+            "shipments": [SHIPMENT_JSON],
+            "total": 1990,
+            "page": 1,
+            "pages": 20,
+            "links": {
+                "first": {"href": "https://api.shipstation.com/v2/shipments?page=1"},
+                "last": {"href": "https://api.shipstation.com/v2/shipments?page=20"},
+                "prev": {},
+                "next": {"href": "https://api.shipstation.com/v2/shipments?page=2"},
+            },
+        },
+    )
 
-    serialized = test_instance.model_dump(by_alias=True)
-    assert serialized["orderDate"] == "2025-06-05T12:52:00.0000000"
+    assert shipments_list.total == 1990
+    assert shipments_list.pages == 20
+    assert shipments_list.links is not None
+    assert shipments_list.links.next is not None
+    assert shipments_list.links.next.href is not None
+    assert shipments_list.links.prev is not None
+    assert shipments_list.links.prev.href is None
 
-    deserialized = Example.model_validate(serialized)
-    assert deserialized.order_date == datetime(2025, 6, 5, 12, 52, 0, tzinfo=LA_TIMEZONE)
+
+def test_shipment_parses_with_minimal_fields() -> None:
+    """Only ``shipment_id`` is required; everything else defaults."""
+    shipment = Shipment.model_validate({"shipment_id": "se-1"})
+
+    assert shipment.items == []
+    assert shipment.tags == []
+    assert shipment.store_id is None

--- a/uv.lock
+++ b/uv.lock
@@ -399,7 +399,7 @@ wheels = [
 
 [[package]]
 name = "idi-shipstation-sdk"
-version = "0.8.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -37,18 +37,6 @@ wheels = [
 ]
 
 [[package]]
-name = "anyio"
-version = "4.13.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
-]
-
-[[package]]
 name = "argcomplete"
 version = "3.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -352,34 +340,6 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore"
-version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
-]
-
-[[package]]
-name = "httpx"
-version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
-]
-
-[[package]]
 name = "humanize"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -402,7 +362,7 @@ name = "idi-shipstation-sdk"
 version = "1.0.0"
 source = { editable = "." }
 dependencies = [
-    { name = "httpx" },
+    { name = "niquests" },
     { name = "pydantic" },
 ]
 
@@ -427,7 +387,7 @@ tests = [
 
 [package.metadata]
 requires-dist = [
-    { name = "httpx", specifier = ">=0.27.2" },
+    { name = "niquests", specifier = ">=3.19.1" },
     { name = "pydantic", specifier = ">=2.9.2" },
 ]
 
@@ -475,6 +435,60 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jh2"
+version = "5.0.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/b1/b2b7389b2e0ddac90a1aecbf4a761db8790de85dace7695c01173ed083cc/jh2-5.0.13.tar.gz", hash = "sha256:f8c78cffb3a35c4410513c3eb7989de36028c84277c04f07c97909dd94c23a75", size = 7322505, upload-time = "2026-05-29T05:21:43.516Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/96/c38d3555cc9bbb1c309c896e99dbb0b1f76308bed7f2d6226cdbeaeb3eee/jh2-5.0.13-cp313-cp313t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:2195557f5953ceee743d0eaab0b09ec537bbc1b9a2c6c1463106bfca9b03805f", size = 601454, upload-time = "2026-05-29T05:19:23.763Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/84/a3043ddaf636cec0f4c3aa179a9ef3a59db3d06f770ab6007133ca31bc5f/jh2-5.0.13-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e734f8a5cf002316cc81b80d8a91a0f7c62d631270abd913746644fb9ae288d", size = 384187, upload-time = "2026-05-29T05:19:25.504Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/8b/72dba3fb64bf01355a0bbd78cbe0a2635759d4a6f273c1b118760ca8ecf0/jh2-5.0.13-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ba5e545b3209e8aa5b6af88e7032814473e57d60d32d3fc6b6185453733a4b26", size = 389346, upload-time = "2026-05-29T05:19:26.926Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/2e/6f07e42de6101d4555f14be1e4f42a056c9a44d7ee8f745b3c188c96cbe0/jh2-5.0.13-cp313-cp313t-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:2a37164eb8f2462268e6252db93b009cb685fa060b62ad217bf1b333b450c68d", size = 510278, upload-time = "2026-05-29T05:19:28.175Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a5/85682dcc959682aede0f80206a16574c51af51ed26eb1e87252fd31c6ded/jh2-5.0.13-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b4eae2d5bc1a91033450fd4381c04f33db7d4c9cfd31046c4708c8c1323c06d0", size = 503090, upload-time = "2026-05-29T05:19:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4c/a8a301d494c0a1c2859951d44b4fa54f3b2db91826c719ce5be8b662c5c8/jh2-5.0.13-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40d0a10036cdf8bf1a36b07c10b69ad0d08ce31d99b8962e3d055ee417fe3423", size = 402843, upload-time = "2026-05-29T05:19:30.505Z" },
+    { url = "https://files.pythonhosted.org/packages/21/5f/5f9e0933f458a89005af3b2aa7d1c61cc3cc57c8a633fd54a95acff85121/jh2-5.0.13-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ad4d68340e38a8474a48c424e2929d3e2e82e35e4e8ff1188decb1985d1b4d7", size = 386327, upload-time = "2026-05-29T05:19:31.988Z" },
+    { url = "https://files.pythonhosted.org/packages/75/3d/353ec4a6763e8b6be8d162e6b23f7e1499e75b1bb934cee1e5b5fc062f1e/jh2-5.0.13-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3f8c5e81254b986f8abe9fd974e7ed595aeaead3f3066ce9ed95dfff236ceca9", size = 406978, upload-time = "2026-05-29T05:19:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/e5/cca58b58cb8bab1891f45da43ef91b498ff93d573a1a2836af11962ccfb8/jh2-5.0.13-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:da030729eb8ef386569e78c10e2429adb10026ce82989fdeb906b037314d66c7", size = 560030, upload-time = "2026-05-29T05:19:34.879Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/c9/c3391d8607781016daa1881d8d80f81e0cf0302ff06c86342c492279cf48/jh2-5.0.13-cp313-cp313t-musllinux_1_1_armv7l.whl", hash = "sha256:a5d2ceb2e9d42ac236f0da7b2f9e8237818d32a10d892b06f30f7160ee4365ae", size = 664407, upload-time = "2026-05-29T05:19:36.138Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/b4/3375744e2f33d097da241dfd5262c9997a87c2b948db2385fbf100c7dd12/jh2-5.0.13-cp313-cp313t-musllinux_1_1_i686.whl", hash = "sha256:1f4dffe1c6ed0d4b0d2d9a45d064622bb786cbf87db35eac469dd4c376ac6fb6", size = 625242, upload-time = "2026-05-29T05:19:37.93Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2f/e33763b1f66817bd8c848777f05cf3781ad9ee1c642741458bfb66da1921/jh2-5.0.13-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:bdeb48657db508e8bc299744aa431798efdf090feb3959cf0123167c9251ebb0", size = 591124, upload-time = "2026-05-29T05:19:39.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/92/5a8de2f6936c7af77555299732795f4607d2cefb974ad485acf25b3f998b/jh2-5.0.13-cp313-cp313t-win32.whl", hash = "sha256:b41867d5decd7cd62e12cdacfc45c5d8f6eae872578ae01d78900174d5e47b82", size = 238101, upload-time = "2026-05-29T05:19:40.917Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/71/0f7ba74bb6681e60e871284772a216a50cfd63f4f62ef52edd13d8a7c057/jh2-5.0.13-cp313-cp313t-win_amd64.whl", hash = "sha256:62aee4bd128e17871980e4847cc4b94b67651de612bc96dd3d7ebf647c68a6e4", size = 245923, upload-time = "2026-05-29T05:19:42.338Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/dc/11434a6deee70630f5f38cc40813692e1faadd4259f242f4f810f35709eb/jh2-5.0.13-cp313-cp313t-win_arm64.whl", hash = "sha256:267aaa7a96f54452e1e07c7701799bc7817e1f3bb2de09301b2c492841e4c98e", size = 242596, upload-time = "2026-05-29T05:19:43.853Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f8/e9e82b7b51947edbf762edb26eb9bcfadda10fc7526d092244528e9cea8c/jh2-5.0.13-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:1dd137086b13d55a53c4b7b8b75869c824060a4d35615e4f49180ae58c7783f5", size = 601736, upload-time = "2026-05-29T05:19:45.14Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f4/e82b4c5797c20facb2f1b54f893a422f8ba44f83bc66da3d60d90a1c3064/jh2-5.0.13-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75d0b2bffb2e260a0f3578a11a4999a713c94d1bd8de7cfe692c840e20ae83cf", size = 383983, upload-time = "2026-05-29T05:19:46.687Z" },
+    { url = "https://files.pythonhosted.org/packages/27/df/f439704e7a884b5bd0181188b30217d71d48ce6bb9a9d7e8378d00ed3497/jh2-5.0.13-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f681e197bf6552df3bb7a3abfd676e81316b69e36e7263e72383477174032ca2", size = 389233, upload-time = "2026-05-29T05:19:47.973Z" },
+    { url = "https://files.pythonhosted.org/packages/49/9e/c2cbdb2261724edb83fa0bdb260f75ad9b091189ada1651608f8ade71906/jh2-5.0.13-cp314-cp314t-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:bde7e7ff0f17e87aca9ef23f66b80540a2de0ff8e2c26af55eb2e288a2a5f74f", size = 510268, upload-time = "2026-05-29T05:19:49.183Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/cf/65925f2aaea92e5f4a90a578b86a975bf6327ad53d82035a4d94f8f63580/jh2-5.0.13-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6f8d364d53cc0854d910f2305726a8254acb527f13fa933dc213a591e21e7ffa", size = 503003, upload-time = "2026-05-29T05:19:50.699Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fc/684ae4efe7568ec9f8ce427b6ecdc7387f870b3bbdcee75c370326685865/jh2-5.0.13-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b572daaafbd867bb5c5f324c918704ddd6d76af1cc7c2be483c3649b76ce7940", size = 402856, upload-time = "2026-05-29T05:19:52.004Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/41/009c8b95f471ca83667e63e87a845f634f7b100f9fa2c1cbfc090c142ec9/jh2-5.0.13-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0772ad66f346038fe05cb2928866ff1b21bcaa9ec3f14709fa1d419ed1dc287", size = 386592, upload-time = "2026-05-29T05:19:53.201Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/8b/5b49f66cadc6d89db5339b602c06a9567ef493c33b860324f24a96b390a4/jh2-5.0.13-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b1d8313b13acfdef19c5ff793fdf397bae3d8d75181f6eee62604f13e4ec20a8", size = 406930, upload-time = "2026-05-29T05:19:54.441Z" },
+    { url = "https://files.pythonhosted.org/packages/55/a4/7b997c7787ee6316c6b4f7bc0ff4d80c062ef3288038fbee870ed83f0946/jh2-5.0.13-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:99aedd20daacb32f377152c9103d8d0271f32d1932bd39a5ed2cd2eef97f7e07", size = 559781, upload-time = "2026-05-29T05:19:55.659Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/08/b75afc38215f961ba8d92af64a9e7cba57767829786484c5cb98fc1a1d2f/jh2-5.0.13-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:53b1df29ffe966cde1d2f0085b6acfcd237504627d406a51717ef3849ec88831", size = 664237, upload-time = "2026-05-29T05:19:57.031Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/92/0fad513d95376611b337c631abd0263e641b78b0adbe80f3cf561e614d6e/jh2-5.0.13-cp314-cp314t-musllinux_1_1_i686.whl", hash = "sha256:0ee6a5dd24a1dc0772a89b3498ed20f60167fbc633404b1e02895f04ae66c47c", size = 625249, upload-time = "2026-05-29T05:19:58.447Z" },
+    { url = "https://files.pythonhosted.org/packages/79/28/4f70df7bfaf1cdb560340400b46849cfa96e4b08d2430793501013d7ee8a/jh2-5.0.13-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:521f871864880cabe361060f070516a56a54abc3e96f07bee9ba8b061eada891", size = 591017, upload-time = "2026-05-29T05:19:59.839Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/58/ed891762aa68542fa7969c4cbb109817231740f342931165f60ea7a2a923/jh2-5.0.13-cp314-cp314t-win32.whl", hash = "sha256:5909e2273f8b6fcea93c95564aa0f366ff9261a544a7a5d640ea95341321cc37", size = 238041, upload-time = "2026-05-29T05:20:01.228Z" },
+    { url = "https://files.pythonhosted.org/packages/48/13/46ae2bf16baad7841526dba44668083f9de3e427027e4fa44a567cb778d6/jh2-5.0.13-cp314-cp314t-win_amd64.whl", hash = "sha256:2cc4923ac6f57753e0cb4aef054a04f5d5c744b274dabf863f695fa3c2fd75f9", size = 245861, upload-time = "2026-05-29T05:20:02.757Z" },
+    { url = "https://files.pythonhosted.org/packages/79/49/3652903fc82c0e5c82e9caa3445e3e514b168969c2dae3da15c46627661f/jh2-5.0.13-cp314-cp314t-win_arm64.whl", hash = "sha256:d3cf203de31371289d4c1e6b4d30c9f6de95b2bd2b300fe5468ff946299d0e48", size = 242699, upload-time = "2026-05-29T05:20:03.9Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f3/8c151f371f7962902e6f1f494b50abc1b8be27305a9d12cb88cf049c5a80/jh2-5.0.13-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:3f54095cde010ff4e52f23dda92b31d3d3160c64f5f23fc6e181f8c7938afd33", size = 618581, upload-time = "2026-05-29T05:20:05.043Z" },
+    { url = "https://files.pythonhosted.org/packages/71/3f/a2d5458586c024e0076ae8182dcbb71450bd9d4dd65ffdaa659313461bd4/jh2-5.0.13-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f810dd02b4a9647eacbe4eab617111c0e3ffc68e923e3ff172948db601d2ba1e", size = 392776, upload-time = "2026-05-29T05:20:06.178Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/1f/cf205104cfcef4bd26aa2b736f36ddf3739b69ddaf14d23a5f7697673d74/jh2-5.0.13-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29c23f3937f257beb5cd5b17f8727404f1267ff25d26e54c0a35d5defd0c895e", size = 397943, upload-time = "2026-05-29T05:20:07.479Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/82/bd218132e5a081293cf3d7de5cf41d871f3f88808c23f6c6aebbe073fb5e/jh2-5.0.13-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:c697b250a935030a128b45b41f507a4d33a082d8b8e12311c7e73fbb3970f057", size = 520351, upload-time = "2026-05-29T05:20:08.936Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/78b564899237909ddf4103569be59ea31b6c00f8b4f1c178cc57c6e4e45d/jh2-5.0.13-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:47d3203ed6fec39df4922764817979fad3a13d22cf750adc9cf9dc2b3399eacf", size = 511162, upload-time = "2026-05-29T05:20:10.239Z" },
+    { url = "https://files.pythonhosted.org/packages/db/3a/b59157363139436cb60620353aa8b687197c9a4ec1eb87952004a8843e6e/jh2-5.0.13-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a5146468a76bbe8f4035f23a78813c5c433c70c0ca44eb0ba5558627a9e644b8", size = 411838, upload-time = "2026-05-29T05:20:11.515Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a4/18b35000b00d9fb72003e0eacf66b3af828a0bb897c21a287a33d2025138/jh2-5.0.13-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85d3d338284fbfbe173243c3cc62e510c6fa0d6d023e67da2292bd7578c734e3", size = 395975, upload-time = "2026-05-29T05:20:13.157Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/42/f017b6b7b666e6ef615f7c64fd748201d0b20edeed094182c4f37f23a6e8/jh2-5.0.13-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:641f65f5414b8990251bd7609513a696831558f69d2ca77d65dc3f7087f31267", size = 417493, upload-time = "2026-05-29T05:20:14.394Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/fc/054443bd40a9827ade99508482185692530cf56a50d4ad8ed2aba761f11d/jh2-5.0.13-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:cf3dc6f7c14340241260bf63e5d6006b2ee7db45dafcb39c16fdf164ea0240a0", size = 568373, upload-time = "2026-05-29T05:20:15.914Z" },
+    { url = "https://files.pythonhosted.org/packages/47/48/dde093626bb976722c940053ceaa82407bd358e07fa6a1690590456d21b5/jh2-5.0.13-cp37-abi3-musllinux_1_1_armv7l.whl", hash = "sha256:fb8e37ecf37382c02af83da521df5a77561441bc4cbb93b00627e015b7bbf349", size = 673766, upload-time = "2026-05-29T05:20:17.136Z" },
+    { url = "https://files.pythonhosted.org/packages/96/94/edae999301bb28738e17cf54ecd50b7d7d9fd96d9536376bbeb9b8498526/jh2-5.0.13-cp37-abi3-musllinux_1_1_i686.whl", hash = "sha256:296ee44dfad08ccc3857daf433dfa4a555d5b45f2df39503ccdd90ff10b32943", size = 635045, upload-time = "2026-05-29T05:20:18.633Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/5b/d9fd0fc71e43c37c30d581affbb7371fa8177ce211b663457939bbed9e61/jh2-5.0.13-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:1a75eed545420a31ea356e8046b8d86fcf694234dd1035191734a03720fb8a44", size = 599870, upload-time = "2026-05-29T05:20:20.117Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ec/66c17d8aec77d41c8f93145dd7faa7138b9f1bc370fa685008bf92d75f9f/jh2-5.0.13-cp37-abi3-win32.whl", hash = "sha256:4812710810010c428db04e9290a13117f7b7c5a3a663b46a0586fe101cf25c9d", size = 245231, upload-time = "2026-05-29T05:20:21.275Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/107f16a84c8becef5281040fdb50681f06e4615bb4a754f211abe7d61a6f/jh2-5.0.13-cp37-abi3-win_amd64.whl", hash = "sha256:5d61bc0a62b4eee11039bf29d4bdbb26efcff760dfb9d8e0739740028aa52b0f", size = 252085, upload-time = "2026-05-29T05:20:22.426Z" },
+    { url = "https://files.pythonhosted.org/packages/47/7b/e8baeef7655449a6c9abee0165fcb1c63d12ec5432b8d810ff5910184690/jh2-5.0.13-cp37-abi3-win_arm64.whl", hash = "sha256:3f74dad9036e599eed51576492b00955237b86cf886f96844708a81cd0f5c710", size = 249139, upload-time = "2026-05-29T05:20:23.558Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/1e/be44f6e9ff5689fcdf9a2c0ed30880fd5da303676d89d6457a603450b7b1/jh2-5.0.13-py3-none-any.whl", hash = "sha256:2b311414989da48a155721fe47d0dc3e3b75360efd62d779aaff72d786be91cf", size = 98909, upload-time = "2026-05-29T05:21:42.086Z" },
 ]
 
 [[package]]
@@ -632,6 +646,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "niquests"
+version = "3.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "urllib3-future" },
+    { name = "wassima", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/ee/9a33c6d343b298ca7faca7d5a25693aca62f7f2553f2f0e6e54f844c3a75/niquests-3.20.0.tar.gz", hash = "sha256:dba85ce23ac5052f0a1e1c1cf1c017511a993f906686e8b6c84e0b54818fd1dc", size = 1039225, upload-time = "2026-06-26T16:34:39.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/40/ffc07ba89b8138408d930bb8072407fa2f80e1fc45f55ccc10e8e1056b24/niquests-3.20.0-py3-none-any.whl", hash = "sha256:86281a62314d7395f049d748480589e273dc1f429953afbac377fff142860429", size = 213612, upload-time = "2026-06-26T16:34:38.409Z" },
 ]
 
 [[package]]
@@ -871,6 +899,65 @@ wheels = [
 ]
 
 [[package]]
+name = "qh3"
+version = "1.9.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/56/e351e5e85242b3d8db4bb5fe9d2e0487ecce50444c1870a0e6b02cc3fe51/qh3-1.9.3.tar.gz", hash = "sha256:c4e958d0a93a66c4bebc2f75126d4060e9ab93addb9814cb367a1f23a395a7a3", size = 344707, upload-time = "2026-07-08T06:48:26.325Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/28/61ddb2ff5dcde835a17cc0080cccab1fde415009e8abd3f5e7ae604e7b8a/qh3-1.9.3-cp313-cp313t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:f2f5406bb5222f1c2b64c5e887271da6713f2bc95495b1a9437a16af6671d4de", size = 4355940, upload-time = "2026-07-08T06:44:49.05Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/cf/80b01dfff6389d8567e9659461e18af2a002a90dd88070c210cb9091f391/qh3-1.9.3-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:abbee98af62d232c371de518acc9a468bf4ad0d47586782a1683f19d20c57d9a", size = 2162761, upload-time = "2026-07-08T06:44:50.963Z" },
+    { url = "https://files.pythonhosted.org/packages/af/5e/909d200a37ed0fc15084d34d2f14d606f92a4d391c1d937b6359bca692f9/qh3-1.9.3-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0f3a1dc1088421e535328272a4a0bc4a6bcc0533b77c231356d627d7d2daf83c", size = 1857998, upload-time = "2026-07-08T06:44:52.755Z" },
+    { url = "https://files.pythonhosted.org/packages/91/5f/deb8ab66f0a2f126a23ef979f756134e428aa51c9b96b9ce369a73954c1e/qh3-1.9.3-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b5ff577b73d382be9c95ce03ba7bd00c957eadd189dcc5950ef9dcc48565927e", size = 2031651, upload-time = "2026-07-08T06:44:54.478Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/af/f1f496bac18b3d0dfa15f38b4e8491a9c6b736baf9065154bc800771bc59/qh3-1.9.3-cp313-cp313t-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:ca4e3b2856b716a64f50f6602c3d8e56f43e723f5aca68872be61df1b0127a67", size = 2029609, upload-time = "2026-07-08T06:44:56.546Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/62/a68b0af5c52efe5f21f84b3419f5a7ecc61da72d22cc71066033a1cdae18/qh3-1.9.3-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:855353247c671964535159fb9cafe100236c90c55eccbbcaa2b7ab542aaa8bce", size = 2027961, upload-time = "2026-07-08T06:44:58.543Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/7e/11fbee3dd24eae3d135ffbbf175bcc726cec39dbcbe91690e792dce2b4ac/qh3-1.9.3-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:45f1bcc1aa02152fe9fd1e7b7fe5bec77d74e4a0fc9d5057192e7c128a37602d", size = 2083098, upload-time = "2026-07-08T06:45:00.406Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/99/e5c0511e84a8271810450f8845bb93f7cf1819e13d566e32924e4e565e7a/qh3-1.9.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:09e1cf7bca22c15c70c37898886914e9a6f0565609c9d95eecb71f098e5135df", size = 2362940, upload-time = "2026-07-08T06:45:02.07Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/2c/2b336a4af4d7d49dd029e90beaab0aa1b9a2a0b77f6bbb0b2e2f6d051b87/qh3-1.9.3-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:46e44eba4cedeb02135bd6dcb5864b3496f8101c228ffb4bf779f04136d0daf7", size = 2012632, upload-time = "2026-07-08T06:45:03.836Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/45/df99809e01cc8f3cd7f190b496278bfa187fef4e5ebdc50d7a1318562476/qh3-1.9.3-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:9f80f98b41b1916ac2558b240696749a2feb475976600faaba6459457fe8740e", size = 2351798, upload-time = "2026-07-08T06:45:06.157Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d1/3a24772b1df252fc3d87300b3f8c2715b64fef6161f8a008964d4032e6fd/qh3-1.9.3-cp313-cp313t-musllinux_1_1_armv7l.whl", hash = "sha256:bf07f32898683cb329cc779c3ea45ce8563e9a4a64507b85e5f07a737f1bfb64", size = 2129252, upload-time = "2026-07-08T06:45:07.947Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/87/083d89449010be747b6b76e2241aab68e33adde4488d7387827eb978cf87/qh3-1.9.3-cp313-cp313t-musllinux_1_1_i686.whl", hash = "sha256:057ae60343ae381347651381fcb62400e36c92a91894fff84352749fac651d6d", size = 2228460, upload-time = "2026-07-08T06:45:09.626Z" },
+    { url = "https://files.pythonhosted.org/packages/af/d4/2acc408d645bc71d170254be76deafb35a3322477121334d24566f46b1c9/qh3-1.9.3-cp313-cp313t-musllinux_1_1_riscv64.whl", hash = "sha256:abd370cc044bdd74643cc88bc76fb6cfac50bad3d437732cd559125a30025b3c", size = 2119492, upload-time = "2026-07-08T06:45:11.361Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a2/3732631f8d329b1f5cb6f7331e11594c2d968ffbfc206df078ee4dda2873/qh3-1.9.3-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:b34a19c879d517d8a412e4c82bd596a645e2d7aa2cec8260cfead94e2ea17e40", size = 2586455, upload-time = "2026-07-08T06:45:13.037Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6c/02e7f4b0ee9518a19b76b5994b757e6e919761b21f6838bc4dc3dc54981e/qh3-1.9.3-cp313-cp313t-win32.whl", hash = "sha256:942c27541367395e40771653c8e719c493e267555e201d6db3ae3f99fa8cc88c", size = 1854032, upload-time = "2026-07-08T06:45:14.862Z" },
+    { url = "https://files.pythonhosted.org/packages/19/3f/74e386cc2c60276bba73cf5ef71cd1d1b05213713f4493d705e6884f71cd/qh3-1.9.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1c67e5fd75758c415b339cee766819f841b9c9e804b57bcf1ebaa3e1f02c3b7d", size = 2119347, upload-time = "2026-07-08T06:45:16.591Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/17/e004a53f9d3dd0f54f07cb8737bb059992a5d63e7ca3954542ce84d6a643/qh3-1.9.3-cp313-cp313t-win_arm64.whl", hash = "sha256:baf940df087ede64dbacab286d0c21e0841220ba19172810d2b5e5f2113299e4", size = 1967111, upload-time = "2026-07-08T06:45:18.153Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/b8/8a81019cd592b4fa33c9d37430ec758e910224204dbc971d55042f5cd21a/qh3-1.9.3-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:6d82134de2a5771ce91754a7a735feb6d29b02892cf0f27764e364add7ba7cbb", size = 4357106, upload-time = "2026-07-08T06:45:20.045Z" },
+    { url = "https://files.pythonhosted.org/packages/65/2b/2f64bacfb68ee41cb4e9f1462fbc3a8cf141d4deb63767c036267935629e/qh3-1.9.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0baf4d271c55c980ea7ccc20e8270093f2d7e4a9e4f8741b25e31f13d2c4e91e", size = 2163136, upload-time = "2026-07-08T06:45:21.892Z" },
+    { url = "https://files.pythonhosted.org/packages/31/61/2fc4b3cba60f84f0bf0b69f445a5f9f4be50931fb9bce466dcb25fe84b52/qh3-1.9.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1b16ba15e67825425d5911812d32f6fd877c2a43c374d611ac4980f32915163", size = 1857929, upload-time = "2026-07-08T06:45:23.67Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/7a/fdf783bb1f23c4d688a9921df746e28076f70b3385f950bccb2fd41358bd/qh3-1.9.3-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9896c2a4d5a8a33ce3e7aea8d30afbf8060c339f0bb8586a4244f58b271e54f5", size = 2031980, upload-time = "2026-07-08T06:45:25.615Z" },
+    { url = "https://files.pythonhosted.org/packages/09/d6/e7134ba767424824c246830ef5e9939c8fca23cdda7a5741e5074b3717f5/qh3-1.9.3-cp314-cp314t-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:6e652434896d957f9bd2b16c4d2d0d9375f48955420fdb923a6bc8ce8e5f1dc2", size = 2030009, upload-time = "2026-07-08T06:45:27.404Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/78/59d2dfeb2a75c23da8fb653ec003a57585c3bde800d3d9d6ef2aaf634333/qh3-1.9.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a662710f2acfc1ee8f48650137e3cdaf586ba4022aaebd4f02f6792dbb70ea1d", size = 2028608, upload-time = "2026-07-08T06:45:29.153Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/bc/8e9cbff13f7422d169fb2ca14cb361513394051d000b8289543b5a279f7b/qh3-1.9.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:74d60ea5e9cb6d9410a103a1200c8c390c6885adbfae3004d7c71b4f0a84f56e", size = 2083455, upload-time = "2026-07-08T06:45:31.028Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/69/3a33db1c1f87361cb43fc314cad6027a4429b178821f532f854e5b94b6c3/qh3-1.9.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9b6151fd1041f3427a29f6063814d31a2d0f6cdf35b3293686df750117ebe790", size = 2363968, upload-time = "2026-07-08T06:45:32.837Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ea/6d174e114a28385ab35d5b8644e6c92adb4959da9b85544ce061e53f8e95/qh3-1.9.3-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:3043b4eb7ece93cebbbd905673462d8de831ea6b4d3ca7d2e02bf5ceaccd9cdd", size = 2013065, upload-time = "2026-07-08T06:45:34.672Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/7b/4f6f8147c2906630fd8deb3b158318f67a5c7cf61ef1d135882b370715fa/qh3-1.9.3-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d6e379322363285bf459749bc13e43a3050426a2c3f76ea3e9374cc373ed0bc6", size = 2352174, upload-time = "2026-07-08T06:45:36.269Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b2/c13e6757ebd436dc31540700054406c2c091cd9a0f71665a257abb93f3ba/qh3-1.9.3-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:2a3b347e37f9b8f624f881d51b7a88c7190c1feafaed2ccb8fb5f9fe3ae87ab3", size = 2129379, upload-time = "2026-07-08T06:45:37.817Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/23/680a5f777ceddbb9cc72b6f780738a416505608c580120cdbfa9212b3212/qh3-1.9.3-cp314-cp314t-musllinux_1_1_i686.whl", hash = "sha256:f2d2ca26dde0b6f8ea3a13b1bb73e64d405f6248e459a799cd21df04dd235ed1", size = 2229256, upload-time = "2026-07-08T06:45:39.764Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/7e/a40336759ea057185c43d992790bd04181face7b474c1e48c132f6ba5f64/qh3-1.9.3-cp314-cp314t-musllinux_1_1_riscv64.whl", hash = "sha256:75f2ad4bd4e1c864ee0ab8eabc1357578b2641693af83d474808a60d502794ea", size = 2120668, upload-time = "2026-07-08T06:45:41.572Z" },
+    { url = "https://files.pythonhosted.org/packages/22/14/d2efd5bf4d69535f782675dc65bbd934920d5260247e9c0cd49270c65d09/qh3-1.9.3-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:fbfb3068bf89fd1aa936e8f2eceb557c3dff1dcd29ffb3c6a51941a4c784ebcd", size = 2586836, upload-time = "2026-07-08T06:45:43.226Z" },
+    { url = "https://files.pythonhosted.org/packages/40/7a/193a998082f184576d076f6d0bad60861f4d50d7759d7f8c8abe1b8be4c8/qh3-1.9.3-cp314-cp314t-win32.whl", hash = "sha256:912de0904dad032eaf80cd5c35f2ce4c4414884e153d619c0f85b9c138ce6dd7", size = 1854194, upload-time = "2026-07-08T06:45:44.913Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/dd/1883e376065a09487d323c1de7146c1089056b9189a5300c55affe626f3d/qh3-1.9.3-cp314-cp314t-win_amd64.whl", hash = "sha256:5b05e3032640579c866f31335112978eec850afd29e0405f28d359f3a3525200", size = 2120029, upload-time = "2026-07-08T06:45:46.646Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ca/3463d17a4fc64c5a60aeeb99bd6388acb9d44d8ef98f2bda329c9690c842/qh3-1.9.3-cp314-cp314t-win_arm64.whl", hash = "sha256:cf886c4f39d30dcb11ffa4ca6797638d4ee9d28cf2ebf7996a0abc749a6838f5", size = 1967768, upload-time = "2026-07-08T06:45:48.586Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/69/b0f4f0ee4b4fef3f0ad80b2f348d74e75b478fe7d1537aa8361af59116c6/qh3-1.9.3-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:982a6437a670fba0d4de5ce0568765e1c5ecff602d4ada3d549ec82a16cba176", size = 4374650, upload-time = "2026-07-08T06:45:50.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/17/662048426269f5dedf87078932f766935fc41fed9cf391331b84011cc76c/qh3-1.9.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67fa718120fdbb2319e733798030f6c277e04ca53aa9fa696e7ef09e691b9205", size = 2168771, upload-time = "2026-07-08T06:45:52.562Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/49/0a7b3b655cf1f18827ef9b1bd063d0d8b79a84499b1816829f658a1a25bb/qh3-1.9.3-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0f26e4f305bdf2d994e09b72ceabf41ead962857b7cd7fe601e8e3be0e621e99", size = 1860707, upload-time = "2026-07-08T06:45:54.363Z" },
+    { url = "https://files.pythonhosted.org/packages/28/b0/410d20392e99e6f7638c7f9718edc7b1f4cc54b4b89e00fdcb86106cccc9/qh3-1.9.3-cp37-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b7f2805b530eee3e8702469186cb1c0d43085e5b03295602aabbccbb03cb56b9", size = 2037331, upload-time = "2026-07-08T06:45:56.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/25/f494b7fd92c9fccc1d984bbdcf4e23f2a2608991e80556f2491ebea382ec/qh3-1.9.3-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:2a6e1a05f38be8dc914466f4b2bacf0988725b1353bba0e65b34b4a5f25a1888", size = 2036816, upload-time = "2026-07-08T06:45:58.605Z" },
+    { url = "https://files.pythonhosted.org/packages/72/74/f10ed1841d31e14ea474aec7950465d7f1b4c933731c05d34768e6035710/qh3-1.9.3-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16e40de89dad0cf0175b03ed0e258862c7ed49ea38f1d608c6bc2fb6597879c2", size = 2036892, upload-time = "2026-07-08T06:46:00.382Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3a/fdaddd6803ada1d8c64729c709de5c653a2a099e003a03e7380ab241d6d6/qh3-1.9.3-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c97708330b7e16fcac33167feb2a6368c9fac41d937b67f53a36e544c13a0bac", size = 2086485, upload-time = "2026-07-08T06:46:02.707Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d2/b944c33428622f3ad6cf222b2a8948c693e8b262c5c5700742e09f743bcb/qh3-1.9.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b0f8d18b683cbd1f96f375693fa03392ef2dbf6e79be3666aae6f36402f6072c", size = 2368322, upload-time = "2026-07-08T06:46:05.027Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/aa/61f31fd8be1e922882aeb9088fadc43f8fde69878d8991d7fe0e6203b59d/qh3-1.9.3-cp37-abi3-manylinux_2_39_riscv64.whl", hash = "sha256:9890c7c35da33e972f23c01801d5b1336ac745bf7d66dc094e20091307644b20", size = 2016075, upload-time = "2026-07-08T06:46:06.594Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e3/80bdeeb24770a5766c0032750f26c1479511c4c4eecef2181737a9aba233/qh3-1.9.3-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:35818b5172748cb031a125154c450bbc65d4599ba33186b341ef62c99fb9c8d5", size = 2356576, upload-time = "2026-07-08T06:46:08.391Z" },
+    { url = "https://files.pythonhosted.org/packages/28/fb/dfd30dc723e6ec07a79f3d65913f80efa73f8a232d0fadfa198f7fa81804/qh3-1.9.3-cp37-abi3-musllinux_1_1_armv7l.whl", hash = "sha256:32659b667cb52eda837b6f094af294dbfd262c9fc6a986e76eea4d7e68595224", size = 2131769, upload-time = "2026-07-08T06:46:10.185Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e7/846ba1f960ecb1a6c88c8888a07a2a22ddfd6516d82882f8d44d9f54de48/qh3-1.9.3-cp37-abi3-musllinux_1_1_i686.whl", hash = "sha256:69b708784a73239db3c248f92b7c4cb06253e667a02f278af9aa8c6daf7fd7f9", size = 2233604, upload-time = "2026-07-08T06:46:11.944Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/30/35070d36d64469aee26d95f78782af3b38525fe4499b13b3dfe92bf8fff1/qh3-1.9.3-cp37-abi3-musllinux_1_1_riscv64.whl", hash = "sha256:676f443b7fbe14aaee31dae3bccea833c90b3c06558b473856816efa8bef8ebb", size = 2125972, upload-time = "2026-07-08T06:46:13.733Z" },
+    { url = "https://files.pythonhosted.org/packages/06/4c/780906fabe96d23c93efbbe4652e9eb0820eb76af2160b291a4c40eb3cf0/qh3-1.9.3-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:56a348d02c798f71fa4c616dabc3127bcf1d418fd0341cc9213bfd5cac41fd1f", size = 2590861, upload-time = "2026-07-08T06:46:15.677Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c9/a8a90f3e372ee83a88064488af3735334fbcbf4c3939f9e365ba4d438160/qh3-1.9.3-cp37-abi3-win32.whl", hash = "sha256:2ba632b022c983f00aeef2bf8fb1340e1489621ce96d9bb08968d0452c489577", size = 1866705, upload-time = "2026-07-08T06:46:17.452Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/0d/b9fc87b886dea1696985817443eb3d2314ab1f8f25740abac922f5f346f6/qh3-1.9.3-cp37-abi3-win_amd64.whl", hash = "sha256:e9b9dd61ce08f030f405844672d2699022141e04e0aa95ab19d3a14df9fe1c2c", size = 2128238, upload-time = "2026-07-08T06:46:19.526Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/06/a94c52f5640f14b47b1e8a961c094156f073d743bbb422bc0cb744739f90/qh3-1.9.3-cp37-abi3-win_arm64.whl", hash = "sha256:b2da0ea8924a1e3ce4bb78286494422965dc39dbd548b34094ff539adc02cdbc", size = 1976500, upload-time = "2026-07-08T06:46:21.256Z" },
+]
+
+[[package]]
 name = "releases"
 version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1099,6 +1186,20 @@ wheels = [
 ]
 
 [[package]]
+name = "urllib3-future"
+version = "2.22.900"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "jh2" },
+    { name = "qh3", marker = "(platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'ARM64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'armv7l' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'i686' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'ppc64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'ppc64le' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'riscv64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'riscv64gc' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 's390x' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'x86' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'ARM64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'armv7l' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'i686' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'ppc64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'ppc64le' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'riscv64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'riscv64gc' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 's390x' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'x86' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'ARM64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'armv7l' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'i686' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'ppc64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'ppc64le' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'riscv64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'riscv64gc' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 's390x' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'x86' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/33/a1dddc4f816657bc4f02be0d36d859413767a7efb5c1a694a55e112db407/urllib3_future-2.22.900.tar.gz", hash = "sha256:3161900c00cf41db90dd3d938c1d14960faab475dd6ca0bf5ecd06112327c714", size = 1303302, upload-time = "2026-06-26T14:30:22.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/a9/3ec7c4aae747d6c7d9e55ef3f53a8b411c63dd9411e284427c062084a868/urllib3_future-2.22.900-py3-none-any.whl", hash = "sha256:803976fe865f03d61d5ddc17dbdbac2bacc08202aad303f282cc4af319ddbfd2", size = 775602, upload-time = "2026-06-26T14:30:20.606Z" },
+]
+
+[[package]]
 name = "virtualenv"
 version = "21.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1111,4 +1212,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/92/58199fe10049f9703c2666e809c4f686c54ef0a68b0f6afccf518c0b1eb9/virtualenv-21.2.0.tar.gz", hash = "sha256:1720dc3a62ef5b443092e3f499228599045d7fea4c79199770499df8becf9098", size = 5840618, upload-time = "2026-03-09T17:24:38.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl", hash = "sha256:1bd755b504931164a5a496d217c014d098426cddc79363ad66ac78125f9d908f", size = 5825084, upload-time = "2026-03-09T17:24:35.378Z" },
+]
+
+[[package]]
+name = "wassima"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/9f/be43f3a97d27bd3bcdd572024ed082b55f486e0541834061da6acf9c77c7/wassima-2.1.2.tar.gz", hash = "sha256:f74b5441151728c54118ece6d747cfe92b2c595a3d062a1955f42a2bc894cd10", size = 139636, upload-time = "2026-07-07T14:01:57.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/94/5ccf60801c011725de5deaa4efc0db9a3719c56c77aac8716ce2def3d790/wassima-2.1.2-py3-none-any.whl", hash = "sha256:9a5779e8ade39960973c6cc17e095cc998d6345ab3dbdd1ec2d7fde8c356fb82", size = 130729, upload-time = "2026-07-07T14:01:56.343Z" },
 ]


### PR DESCRIPTION
## What

Rewrites the SDK as a v2-only client, released as **1.0.0**. v2 "shipments" are v1 "orders" (v2 has no order entity), so the client becomes shipments-first:

- `api-key` header auth against `https://api.shipstation.com` (replaces v1 basic auth against `ssapi.shipstation.com`)
- `list_shipments` / `iter_shipments` (auto-pagination) / `get_shipment` / `get_shipment_by_external_id`, with full `ShipmentListParameters`
- `list_carriers()` — v2 shipments carry `carrier_id`, not `carrier_code`; consumers resolve codes through this
- `list_tags()` — v2 tags are name-based (no IDs)
- Rate-limit-aware retries on 429 honoring `Retry-After`
- HTTP via **Niquests** wrapped in a `Session`, matching the in-house SDKs (Chimera's core-sdk/local-api-sdk)
- All v1 endpoints/models and the `America/Los_Angeles` datetime machinery are removed — v1 consumers should pin `<1` (core already caps its pin in its companion PR)

## Testing

13 tests (session recorder pattern: pagination walk, retry budget and `Retry-After` bounds, param serialization, api-key header), `mypy --strict`, ruff `ALL` — all green. Also smoke-tested the real session path (base-URL merging + header propagation) against a local HTTP server.

## Release ordering

Merge → tag `v1.0.0` → PyPI trusted publishing, **before** merging the Chimera PR (impressdesigns/chimera) that depends on it. The core PR (impressdesigns/core) is independent of this release timing since it caps `<1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYCSX7p4b7KZBH8kDUapze

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYCSX7p4b7KZBH8kDUapze)_